### PR TITLE
Fiche de personnage CG Version 3.3

### DIFF
--- a/cog.css
+++ b/cog.css
@@ -259,11 +259,13 @@ td.sheet-buff-text {
 /* TABS */ 
 
 div.sheet-tab-content { display: none; }
+input.sheet-fp1:checked ~ div.sheet-fp1,
+input.sheet-fp2:checked ~ div.sheet-fp2,
+input.sheet-fp3:checked ~ div.sheet-fp3,
 input.sheet-tab1:checked ~ div.sheet-tab1,
 input.sheet-tab2:checked ~ div.sheet-tab2,
 input.sheet-tab3:checked ~ div.sheet-tab3,
-input.sheet-tab4:checked ~ div.sheet-tab4,
-input.sheet-tabv:checked ~ div.sheet-tabv { display: block; }
+input.sheet-tab4:checked ~ div.sheet-tab4 { display: block; }
 input.sheet-tab {
     width: 110px;
     height: 18px;

--- a/cog.htm
+++ b/cog.htm
@@ -1,5 +1,179 @@
 <!-- **** SCRIPTS / SHEET WORKERS -->
 <script type="text/worker">
+
+    function consoleLog(l,m) {
+        m = m || '';
+        if (m != '') m = ' : ' + m;
+        console.log('** CO sheetworker' + m + ' <<<');
+        console.log(l);
+        console.log('** CO sheetworker' + m + ' >>>');
+    }
+    
+    function importStatblock(text) {
+        text = text.replace(/\r/g, '');
+		text = text.replace(/ \(DM/g, ' DM'); 
+		text = text.replace(/ \(RD/g, ' RD');
+		text = text.replace(/\, /g,' ');
+		var npc = { };
+		var rows = text.split(/\n/);
+        console.log('** CO sheetworker : parsing text <<<');
+		for (var row = 0 ; row < rows.length ; row++) {
+		    console.log(rows[row]);
+		    if (rows[row].toUpperCase().indexOf('DM') != -1) {  // this is an attack line
+				rows[row] = rows[row].replace(/\)$/g, ''); // handle CG statblocks
+				if (!npc['Atks']) npc['Atks'] = [];
+				npc['Atks'].push(rows[row]);
+				continue;
+			}
+			rows[row] = rows[row].replace(/ \(/g, '('); // strip space before '(
+			rows[row] = rows[row].replace(/très /g,'très~'); // handle 'très petite' size
+			rows[row] = rows[row].replace(/créature /g,'PROFIL créature~'); // handle 'créature' mention
+			var items = rows[row].split(' ');
+			for (var item = 0 ; item < items.length ; item++) {
+				if (item%2 == 0) {
+				    var k = items[item].toUpperCase().replace(/\./g,'');
+				    var v = items[item + 1].replace(/~/g,' ');
+				    if (v.charAt(v.length-1) == ')' && v.charAt(0) != '(') v = v.substring(0,v.length-1);
+				    npc[k] = v;
+				}
+			}
+		}
+        console.log('** CO sheetworker : parsing text >>>');
+		return npc;
+    }
+    
+    function processBaseAttributes(universe, pnjObj) {
+        var result = '';
+        var pnj_sagorper = '';
+        var pnj_jetsagorper = '';
+        if (universe == 'COF') { // COF uses SAG (Wisdom)
+            pnj_sagper = 'pnj_sag';
+            pnj_jetsagper = 'pnj_jetsag';
+            if (!pnjObj.hasOwnProperty('SAG') && pnjObj.hasOwnProperty('PER')) {
+                // in case a CG/COC statblock is pasted to COF
+                sagOrPer = pnjObj.PER;
+                result = 'Attention : PER trouvé à la place de SAG';
+            }
+            else {
+                sagOrPer = pnjObj.SAG;
+            }
+        }
+        if (universe == 'COC' || universe == 'CG') { // CG & COC uses PER (Perception)
+            pnj_sagper = 'pnj_per';
+            pnj_jetsagper = 'pnj_jetper';
+            if (!pnjObj.hasOwnProperty('PER') && pnjObj.hasOwnProperty('SAG')) {
+                // in case a COF statblock is pasted to CG/COC
+                sagOrPer = pnjObj.SAG;
+                result = 'Attention : SAG trouvé à la place de PER';
+            }
+            else {
+                sagOrPer = pnjObj.PER;
+            }
+        }
+        var jnor = '1d20';
+        var jsup = '2d20kh1';
+        var pnjAttrs = { };
+        pnjAttrs['NIVEAU'] = parseInt(pnjObj.NC) || 0;
+        delete pnjObj['NC'];
+        pnjAttrs['TAILLE'] = pnjObj.TAILLE || '';
+        delete pnjObj['TAILLE'];
+        if (pnjObj.hasOwnProperty('PROFIL')) pnjAttrs['PROFIL'] = pnjObj.PROFIL;
+        delete pnjObj['PROFIL'];
+        pnjAttrs['pnj_for'] = parseInt(pnjObj['FOR'].replace('*',''));
+        pnjAttrs['pnj_jetfor'] = pnjObj['FOR'].charAt(pnjObj['FOR'].length-1) == '*' ? jsup : jnor;
+        delete pnjObj['FOR'];
+        pnjAttrs['pnj_dex'] = parseInt(pnjObj['DEX'].replace('*',''));
+        pnjAttrs['pnj_jetdex'] = pnjObj['DEX'].charAt(pnjObj['DEX'].length-1) == '*' ? jsup : jnor;
+        delete pnjObj['DEX'];
+        pnjAttrs['pnj_con'] =  parseInt(pnjObj['CON'].replace('*',''));
+        pnjAttrs['pnj_jetcon'] = pnjObj['CON'].charAt(pnjObj['CON'].length-1) == '*' ? jsup : jnor;
+        delete pnjObj['CON'];
+        pnjAttrs['pnj_int'] = parseInt(pnjObj['INT'].replace('*',''));
+        pnjAttrs['pnj_jetint'] = pnjObj['INT'].charAt(pnjObj['INT'].length-1) == '*' ? jsup : jnor;
+        delete pnjObj['INT'];
+        pnjAttrs[pnj_sagper] = parseInt(sagOrPer.replace('*',''));
+        pnjAttrs[pnj_jetsagper] = sagOrPer.charAt(sagOrPer.length-1) == '*' ? jsup : jnor;
+        delete pnjObj['SAG'];
+        delete pnjObj['PER'];
+        pnjAttrs['pnj_cha'] = parseInt(pnjObj['CHA'].replace('*',''));
+        pnjAttrs['pnj_jetcha'] = pnjObj['CHA'].charAt(pnjObj['CHA'].length-1) == '*' ? jsup : jnor;
+        delete pnjObj['CHA'];
+        pnjAttrs['pnj_init'] = parseInt(pnjObj.INIT);
+        delete pnjObj['INIT'];
+        pnjAttrs['pnj_def'] = parseInt(pnjObj.DEF);
+        delete pnjObj['DEF'];
+        pnjAttrs['pnj_pv'] = parseInt(pnjObj.PV);
+        pnjAttrs['pnj_pv_max'] = parseInt(pnjObj.PV);
+        delete pnjObj['PV'];
+        consoleLog(pnjAttrs, 'setting attributes');
+        pnjAttrs['statblock'] = '';
+        setAttrs(pnjAttrs);
+        
+        return result;
+    }
+    
+    function processAttacks(universe, pnjObj) {
+        var result = '';
+        for (var atk=0 ; atk < pnjObj.Atks.length ; atk++) {
+            var atkItems = pnjObj.Atks[atk].split(' ');
+            consoleLog(atkItems, 'attacks found');
+            var atkNom = '';
+            var atkBonus = 0;
+            var atkDM = '';
+            var atkNbDe = 0;
+            var atkDe = '';
+            var atkBonusDM = 0;
+            var atkSpec = '';
+            var parsed = '';
+            for (var item=0 ; item < atkItems.length ; item++) {
+                if (atkItems[item].charAt(0) == '+' && atkItems[item] != '+' && atkNom == '') {
+                    atkBonus = parseInt(atkItems[item].replace('+','')) || 0;
+                    atkNom = parsed;
+                    parsed = '';
+                    continue;
+                }
+                if (parsed.endsWith('DM')) {
+                    atkDM = atkItems[item];
+                    atkSpec = parsed.replace('DM','');
+                    parsed = '';
+                    continue;
+                }
+                parsed += parsed != '' ? ' ' : '';
+                parsed += atkItems[item];
+            }
+            if (atkDM != '') {
+                atkDM = atkDM.replace('d','|');
+                atkDM = atkDM.replace('+','|+');
+                atkDM = atkDM.replace('-','|-');
+                var dm = atkDM.split('|');
+                atkNbDe = parseInt(dm[0]) || 0;
+                atkDe = dm[1]
+                if (universe == 'COC') atkDe += '!';
+                atkBonusDM = parseInt(dm[2]) || 0;
+            }
+            if (atkNom != '' && atkNbDe != 0 && atkDe != '') {
+                newRowID = generateRowID();
+                var atkRow = { };
+                atkRow['repeating_pnjatk_' + newRowID + '_atknom'] = atkNom;
+                atkRow['repeating_pnjatk_' + newRowID + '_atkjet'] = '1d20';
+                atkRow['repeating_pnjatk_' + newRowID + '_atkbonus'] = atkBonus;
+                atkRow['repeating_pnjatk_' + newRowID + '_atkdmnbde'] = atkNbDe;
+                atkRow['repeating_pnjatk_' + newRowID + '_atkdmde'] = atkDe;
+                atkRow['repeating_pnjatk_' + newRowID + '_atkdmbonus'] = atkBonusDM;
+                atkSpec += parsed;
+                atkSpec = atkSpec.replace(/\d+d\d+/g,'[[$&]]'); // search for <numbers>d<numbers> and replace with in-line roll
+                if (atkSpec != '') atkRow['repeating_pnjatk_' + newRowID + '_atkspec'] = atkSpec;
+                consoleLog(atkRow, 'adding attack');
+                setAttrs(atkRow);
+            }
+            else {
+                result = 'Err: impossible d\'analyser le contenu de "' + pnjObj.Atks[atk] + '"';
+            }
+        }
+        
+        return result;
+    }
+
     on('sheet:opened',function(){
         // **** Gestion transition de version
         getAttrs(["VERSION"], function(values) {
@@ -133,12 +307,41 @@
                 });
             }
         });
-        // Activer Buffs PSY
-        getAttrs(['UNIVERS'], function(values) {
+        // Activer Buffs PSY ou de vaisseau
+        getAttrs(['UNIVERS', 'fp', 'PE_ONCE', 'FOR_BUFF1_DESC', 'DEX_BUFF1_DESC', 'INT_BUFF1_DESC', 'PER_BUFF1_DESC', 'CHA_BUFF1_DESC', 'ATKTIRV_BUFF1_DESC', 'INIT_BUFF1_DESC', 'DEFVPIL_BUFF1_DESC', 'DEFVPIL_BUFF2_DESC', 'DEFVSEN_BUFF1_DESC', 'DEFVSEN_BUFF2_DESC'], function(values) {
             if (values.UNIVERS == 'CG') {
-                setAttrs({
-                    voir_psy: '1'
-                });
+                if (values.fp == 'pj') {
+                    setAttrs({
+                        voir_psy: '1'
+                    });
+                }
+                else if (values.fp == 'vaisseau' && values.PE_ONCE != '') {
+                    var for_buff_desc = (values.FOR_BUFF1_DESC) || values.PE_ONCE;
+                    var dex_buff_desc = (values.DEX_BUFF1_DESC) || values.PE_ONCE;
+                    var int_buff_desc = (values.INT_BUFF1_DESC) || values.PE_ONCE;
+                    var per_buff_desc = (values.PER_BUFF1_DESC) || values.PE_ONCE;
+                    var cha_buff_desc = (values.CHA_BUFF1_DESC) || values.PE_ONCE;
+                    var atktirv_buff_desc = (values.ATKTIRV_BUFF1_DESC) || values.PE_ONCE;
+                    var init_buff_desc = (values.INIT_BUFF1_DESC) || 'Valeur DEX pilote';
+                    var defvpil_buff1_desc = (values.DEFVPIL_BUFF1_DESC) || 'Mod. DEX Pilote';
+                    var defvpil_buff2_desc = (values.DEFVPIL_BUFF2_DESC) || 'Rang Pilotage';
+                    var defvsen_buff1_desc = (values.DEFVSEN_BUFF1_DESC) || 'Mod. INT Scantech';
+                    var defvsen_buff2_desc = (values.DEFVSEN_BUFF2_DESC) || 'Rang Electronique';
+                    setAttrs({
+                        FOR_BUFF1_DESC: for_buff_desc,
+                        DEX_BUFF1_DESC: dex_buff_desc,
+                        INT_BUFF1_DESC: int_buff_desc,
+                        PER_BUFF1_DESC: per_buff_desc,
+                        CHA_BUFF1_DESC: cha_buff_desc,
+                        ATKTIRV_BUFF1_DESC: atktirv_buff_desc,
+                        INIT_BUFF1_DESC: init_buff_desc,
+                        DEFVPIL_BUFF1_DESC: defvpil_buff1_desc,
+                        DEFVPIL_BUFF2_DESC: defvpil_buff2_desc,
+                        DEFVSEN_BUFF1_DESC: defvsen_buff1_desc,
+                        DEFVSEN_BUFF2_DESC: defvsen_buff2_desc,
+                        PE_ONCE: ''
+                    });
+                }
             }
         });
         // MAJ Version
@@ -146,7 +349,7 @@
             setAttrs({
                 VERSION: values.VERFDP
             });
-        });        
+        });
     });
 
     on('change:dex_buff1 change:dex_buff2 change:dex_buff3 change:dex_buff4 change:dex_buff5', function(eventInfo) {
@@ -500,12 +703,44 @@
             });
         });
     });
+    
+    on('change:statblock', function(eventInfo) {
+        if (eventInfo.newValue == '') return;
+        getAttrs(['UNIVERS', 'statblock'], function(values) {
+            var messages = '';
+            pnjObj = importStatblock(values.statblock);
+            if (pnjObj) {
+                consoleLog(pnjObj, 'NPC object');
+                messages = processBaseAttributes(values.UNIVERS, pnjObj);
+                if (pnjObj.hasOwnProperty('Atks')) {
+                    result = processAttacks(values.UNIVERS, pnjObj);
+                    if (result != '' && messages != '') result = '\n' + result;
+                    messages += result;
+                    delete pnjObj['Atks'];
+                }
+                // Other attributes go to DIVERS field
+                var divers = '';
+                var otherAttrs = Object.keys(pnjObj);
+                consoleLog(otherAttrs, 'additional data');
+                if (otherAttrs.length > 0) {
+                    for (var other = 0; other < otherAttrs.length; other++) {
+                        var k = otherAttrs[other];
+                        divers += k + ' ' + pnjObj[k] + '\n';
+                    }
+                }
+                setAttrs({ 
+                    pnj_divers: divers, 
+                    sbresult: messages 
+                });
+            }
+        });
+    });
 
 </script>
 <div class="sheet-mainBg"> <!-- FDP -->
     <!-- INPUT HIDDEN Version FdP -->
-    <input type="hidden" name="attr_VERFDP" value="3.2" />
-    <input type="hidden" name="attr_VERSION" value="3.2" />
+    <input type="hidden" name="attr_VERFDP" value="3.3" />
+    <input type="hidden" name="attr_VERSION" value="3.3" />
     <!-- INPUT HIDDEN Univers (COF, CG, COC) -->
     <input type="hidden" name="attr_UNIVERS" value="CG" />
     <!-- INPUT HIDDEN Type de jets -->
@@ -537,10 +772,12 @@
     <input type="hidden" name="attr_PEV_BUFF" value="0" />
     <!-- INPUT HIDDEN Etats préjudiciable précédent -->
     <input type="hidden" name="attr_PCONDITION" value="" />
+    <!-- INPUT HIDDEN PE -->
+    <input type="hidden" name="attr_PE_ONCE" value="Points énergie" />
     <!-- FIN Hidden -->
     <div class="sheet-container"><!-- Identité -->
         <div style="width: 420px; height: 100px; vertical-align: middle; text-align: center;">
-            <img width="400" title="Version 3.2 - 11/12/2018" src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/ChroniquesGalactiques/cog_logo.png"/>
+            <img width="400" title="Version 3.3 - 18/12/2018" src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/ChroniquesGalactiques/cog_logo.png"/>
         </div>
         <div style="width: 250px;">
             <table>
@@ -560,1441 +797,1778 @@
         </div>
     </div> <!-- FIN Identité -->
     &nbsp;
-    <input type="radio" name="attr_tab" class="sheet-tab sheet-tab1" value="caracs" checked="checked"><span title="Caractéristiques"></span>
-    <input type="radio" name="attr_tab" class="sheet-tab sheet-tab2" value="voies"><span title="Capacités"></span>
-    <input type="radio" name="attr_tab" class="sheet-tab sheet-tabv" value="vaisseau"><span title="Vaisseau"></span>
-    <input type="radio" name="attr_tab" class="sheet-tab sheet-tab3" value="equip"><span title="Équipement"></span>
-    <input type="radio" name="attr_tab" class="sheet-tab sheet-tab4" value="config"><span title="Configuration"></span>
+    <input type="radio" name="attr_fp" class="sheet-tab sheet-fp1" value="pj" checked="checked"><span title="Personnage"></span>
+    <input type="radio" name="attr_fp" class="sheet-tab sheet-fp2" value="vaisseau"><span title="Vaisseau"></span>
+    <input type="radio" name="attr_fp" class="sheet-tab sheet-fp3" value="pnj"><span title="PNJ"></span>
     <img class="sheet-imghr-up" src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/ChroniquesGalactiques/cog_hr.png" />
-    <div class="sheet-tab-content sheet-tab1">
-        <div> <!-- Caracs + combat + PV + défense -->
-            <table>
-                <tr>
-                    <td style="width:250px; vertical-align: top;"> <!-- Caracs + Chance -->
-                        <table class="sheet-tabsep"> <!-- Caracs -->
-                            <tr>
-                                <td class="sheet-textfat">CARAC.</td>
-                                <td></td>
-                                <td class="sheet-textbase">Valeur</td>
-                                <td class="sheet-textfat">Mod.</td>
-                                <td class="sheet-textbase">Bonus</td>
-                                <td class="sheet-textfat">Test</td>
-                            </tr>
-                            <tr>
-                                <td class="sheet-boxtitre"><button class="sheet-boxtitre" type="roll" name="JET_FOR" title="Jet de Force" value="@(togm}&{template:co1} {{perso=@{character_name}}} {{name=Force}} {{subtags=Test}} {{carac=[[ @{FOR_SUP}[Dé] + [[@{FOR_TEST}]][Bonus] ]] }}"> FOR</button></td>
-                                <td class="sheet-boxinputlight">
-                                    <select class="sheet-selectmin" name="attr_FOR_SUP" title="@{FOR_SUP} Caractéristique Normale ou Supérieure/Héroïque (règle p.138)">
-                                        <option value="@{JETNORMAL}" selected>N Normale</option>
-                                        <option value="@{JETSUP}">S Supérieure OU Héroïque</option>
-                                        <option value="@{JETSUPHERO}">H Supérieure ET Héroïque</option>
-                                    </select>
-                                </td>
-                                <td class="sheet-boxinput"><input type="number" name="attr_FORCE" title="@{FORCE}" value="10" min="0" /></td>
-                                <td class="sheet-boxinputlight"><input type="number" name="attr_FOR" title="@{FOR}" value="floor((@{FORCE}-10)/2)" disabled /></td>
-                                <td class="sheet-boxinputlight"><input type="number" name="attr_FOR_BONUS" title="@{FOR_BONUS} Bonus au Test" value="@{FOR_BUFF}" disabled /></td>
-                                <td class="sheet-boxinputlight"><input type="number" name="attr_FOR_TEST" title="@{FOR_TEST}" value="@{FOR}+@{FOR_BONUS}" disabled /></td>
-                            </tr>
-                            <tr>
-                                <td class="sheet-boxtitre"><button class="sheet-boxtitre" type="roll" name="JET_DEX" title="Jet de Dext&eacute;rit&eacute;" value="@(togm}&{template:co1} {{perso=@{character_name}}} {{name=Dext&eacute;rit&eacute;}} {{subtags=Test}} {{carac=[[ @{DEX_SUP}[Dé] + [[@{DEX_TEST}]][Bonus] ]] }}"> DEX</button></td>
-                                <td class="sheet-boxinputlight">
-                                    <select class="sheet-selectmin" name="attr_DEX_SUP" title="@{DEX_SUP} Caractéristique Normale ou Supérieure/Héroïque (règle p.138)">
-                                        <option value="@{JETNORMAL}" selected>N Normale</option>
-                                        <option value="@{JETSUP}">S Supérieure OU Héroïque</option>
-                                        <option value="@{JETSUPHERO}">H Supérieure ET Héroïque</option>
-                                    </select>
-                                </td>
-                                <td class="sheet-boxinput"><input type="number" name="attr_DEXTERITE" title="@{DEXTERITE}" value="10" min="0"  /></td>
-                                <td class="sheet-boxinputlight"><input type="number" name="attr_DEX" title="@{DEX}" value="floor((@{DEXTERITE}-10)/2)" disabled /></td>
-                                <td class="sheet-boxinputlight"><input type="number" name="attr_DEX_BONUS" title="@{DEX_BONUS} Bonus au Test" value="@{DEX_BUFF}" disabled /></td>
-                                <td class="sheet-boxinputlight"><input type="number" name="attr_DEX_TEST" title="@{DEX_TEST}" value="@{DEX}+@{DEX_BONUS}" disabled /></td>
-                            </tr>
-                            <tr>
-                                <td class="sheet-boxtitre"><button class="sheet-boxtitre" type="roll" name="JET_CON" title="Jet de Constitution" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=Constitution}} {{subtags=Test}} {{carac=[[ @{CON_SUP}[Dé] + [[@{CON_TEST}]][Bonus] ]] }}"> CON</button></td>
-                                <td class="sheet-boxinputlight">
-                                    <select class="sheet-selectmin" name="attr_CON_SUP" title="@{CON_SUP} Caractéristique Normale ou Supérieure/Héroïque (règle p.138)">
-                                        <option value="@{JETNORMAL}" selected>N Normale</option>
-                                        <option value="@{JETSUP}">S Supérieure OU Héroïque</option>
-                                        <option value="@{JETSUPHERO}">H Supérieure ET Héroïque</option>
-                                    </select>
-                                </td>
-                                <td class="sheet-boxinput"><input type="number" name="attr_CONSTITUTION" title="@{CONSTITUTION}" value="10" min="0"  /></td>
-                                <td class="sheet-boxinputlight"><input type="number" name="attr_CON" title="@{CON}" value="floor((@{CONSTITUTION}-10)/2)" disabled /></td>
-                                <td class="sheet-boxinputlight"><input type="number" name="attr_CON_BONUS" title="@{CON_BONUS} Bonus au Test" value="@{CON_BUFF}" disabled /></td>
-                                <td class="sheet-boxinputlight"><input type="number" name="attr_CON_TEST" title="@{CON_TEST}" value="@{CON}+@{CON_BONUS}" disabled /></td>
-                            </tr>
-                            <tr>
-                                <td class="sheet-boxtitre"><button class="sheet-boxtitre" type="roll" name="JET_INT" title="Jet d'Intelligence" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=Intelligence}} {{subtags=Test}} {{carac=[[ @{INT_SUP}[Dé] + [[@{INT_TEST}]][Bonus] ]] }}"> INT</button></td>
-                                <td class="sheet-boxinputlight">
-                                    <select class="sheet-selectmin" name="attr_INT_SUP" title="@{INT_SUP} Caractéristique Normale ou Supérieure/Héroïque (règle p.138)">
-                                        <<option value="@{JETNORMAL}" selected>N Normale</option>
-                                        <option value="@{JETSUP}">S Supérieure OU Héroïque</option>
-                                        <option value="@{JETSUPHERO}">H Supérieure ET Héroïque</option>
-                                    </select>
-                                </td>
-                                <td class="sheet-boxinput"><input type="number" name="attr_INTELLIGENCE" title="@{INTELLIGENCE}" value="10" min="0"  /></td>
-                                <td class="sheet-boxinputlight"><input type="number" name="attr_INT" title="@{INT}" value="floor((@{INTELLIGENCE}-10)/2)" disabled /></td>
-                                <td class="sheet-boxinputlight"><input type="number" name="attr_INT_BONUS" title="@{INT_BONUS} Bonus au Test" value="@{INT_BUFF}" disabled /></td>
-                                <td class="sheet-boxinputlight"><input type="number" name="attr_INT_TEST" title="@{INT_TEST}" value="@{INT}+@{INT_BONUS}" disabled /></td>
-                            </tr>
-                            <tr>
-                                <td class="sheet-boxtitre"><button class="sheet-boxtitre" type="roll" name="JET_PER" title="Jet de Perception" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=Perception}} {{subtags=Test}} {{carac=[[ @{PER_SUP}[Dé] + [[@{PER_TEST}]][Bonus] ]] }}"> PER</button></td>
-                                <td class="sheet-boxinputlight">
-                                    <select class="sheet-selectmin" name="attr_PER_SUP" title="@{PER_SUP} Caractéristique Normale ou Supérieure/Héroïque (règle p.138)">
-                                        <option value="@{JETNORMAL}" selected>N Normale</option>
-                                        <option value="@{JETSUP}">S Supérieure OU Héroïque</option>
-                                        <option value="@{JETSUPHERO}">H Supérieure ET Héroïque</option>
-                                    </select>
-                                </td>
-                                <td class="sheet-boxinput"><input type="number" name="attr_PERCEPTION" title="@{PERCEPTION}" value="10" min="0"  /></td>
-                                <td class="sheet-boxinputlight"><input type="number" name="attr_PER" title="@{PER}" value="floor((@{PERCEPTION}-10)/2)" disabled /></td>
-                                <td class="sheet-boxinputlight"><input type="number" name="attr_PER_BONUS" title="@{PER_BONUS} Bonus au Test" value="@{PER_BUFF}" disabled /></td>
-                                <td class="sheet-boxinputlight"><input type="number" name="attr_PER_TEST" title="@{PER_TEST}" value="@{PER}+@{PER_BONUS}" disabled /></td>
-                            </tr>
-                            <tr>
-                                <td class="sheet-boxtitre"><button class="sheet-boxtitre" type="roll" name="JET_CHA" title="Jet de Charisme" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=Charisme}} {{subtags=Test}} {{carac=[[ @{CHA_SUP}[Dé] + [[@{CHA_TEST}]][Bonus] ]] }}"> CHA</button></td>
-                                <td class="sheet-boxinputlight">
-                                    <select class="sheet-selectmin" name="attr_CHA_SUP" title="@{CHA_SUP} Caractéristique Normale ou Supérieure/Héroïque (règle p.138)">
-                                        <option value="@{JETNORMAL}" selected>N Normale</option>
-                                        <option value="@{JETSUP}">S Supérieure OU Héroïque</option>
-                                        <option value="@{JETSUPHERO}">H Supérieure ET Héroïque</option>
-                                    </select>
-                                </td>
-                                <td class="sheet-boxinput"><input type="number" name="attr_CHARISME" title="@{CHARISME}" value="10" min="0"  /></td>
-                                <td class="sheet-boxinputlight"><input type="number" name="attr_CHA" title="@{CHA}" value="floor((@{CHARISME}-10)/2)" disabled /></td>
-                                <td class="sheet-boxinputlight"><input type="number" name="attr_CHA_BONUS" title="@{CHA_BONUS} Bonus au Test" value="@{CHA_BUFF}" disabled /></td>
-                                <td class="sheet-boxinputlight"><input type="number" name="attr_CHA_TEST" title="@{CHA_TEST}" value="@{CHA}+@{CHA_BONUS}" disabled /></td>
-                            </tr>
-                            <tr>
-                                <td class="sheet-textfat" colspan="6">ÉTATS PRÉJUDICIABLES</td>
-                            </tr>
-                            <tr>
-                                <td class="sheet-boxinputlight" colspan="6">
-                                    &nbsp;
-                                    <input type="radio" name="attr_ETATDE" value="20" title="@{ETATDE} Jet d'un d20 pour tous les tests" checked >&nbsp;Normal</input>
-                                    &nbsp;
-                                    <input type="radio" name="attr_ETATDE" value="12" title="@{ETATDE} Jet d'un d12 pour tous les tests">&nbsp;Affaibli</input>
-                                    &nbsp;
-                                    <input type="checkbox" name="attr_POISSE" title="@{POISSE} Moins bon de deux d20 pour tous les tests" value="1" />&nbsp;Poisse
-                                </td>
-                            </tr>
-                            <tr>
-                                <td class="sheet-boxinputlight" colspan="6">
-                                    Autres conditions :&nbsp;
-                                    <select class="sheet-carac" style="min-width: 100px;" name="attr_CONDITION" title="@{CONDITION}">
-                                        <option value="" selected>(aucune)</option>
-                                        <option value="A">Aveuglé</option>
-                                        <option value="E">Etourdi</option>
-                                        <option value="I">Immobilisé</option>
-                                        <option value="R">Renversé</option>
-                                        <option value="S">Surpris</option>
-                                    </select>
-                                </td>
-                            </tr>
-                        </table> <!-- FIN Caracs -->
-                        <table class="sheet-tabsep" style="margin-top: 20px;"> <!-- Chance -->
-                            <tr>
-                                <td class="sheet-boxtitre" title="Points de Chance">PC</td>
-                                <td class="sheet-boxinput"><input type="number" name="attr_PC" value="0" title="@{PC} Points de Chance utilisés ou courants" /></td>
-                                <td>/</td>
-                                <td class="sheet-boxinput"><input type="number" name="attr_PCRACE" title="@{PCRACE}Points de Chance de Race" value="0" /></td>
-                                <td>+</td>
-                                <td class="sheet-boxinput"><input type="number" name="attr_PCDIV" title="@{PCDIV} Points de Chance additionnels"  value="0"/></td>
-                                <td>+</td>
-                                <td class="sheet-boxinputlight"><INPUT type="number" name="attr_PCCAR" value="@{CHA}" title="@{PCCAR} Modificateur de Charisme" disabled /></td>
-                                <td>=</td>
-                                <td class="sheet-boxinputlight"><input type="number" name="attr_PC_max" value="@{PCRACE}+@{PCDIV}+@{PCCAR}" title="@{PC|max} Points de Chance maximums" disabled /></td>
-                            </tr>
-                        </table> <!-- FIN Chance -->
-                    </td> <!-- FIN Caracs + Chance -->
-                    <td  style="width:100%; vertical-align: top;"> <!-- Combat + PV + défense -->
-                        <table>
-                            <tr>
-                                <td style="vertical-align: top;"> <!-- Combat -->
-                                    <table class="sheet-tabsep">
-                                        <tr>
-                                            <td class="sheet-textfat">COMBAT</td>
-                                            <td class="sheet-textbase">Base</td>
-                                            <td class="sheet-textbase">Mod.</td>
-                                            <td class="sheet-textbase">Div.</td>
-                                            <td class="sheet-textfat">Total</td>
-                                        </tr>
-                                        <tr>
-                                            <td class="sheet-boxtitre"><button class="sheet-boxtitre" type="roll" name="JET_CAC" title="Jet d'attaque au contact" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=Au Contact}} {{subtags=Attaque}} {{attaque=[[ @{JETNORMAL}cs20cf1[Dé] + [[@{ATKCAC}]][Bonus] ]] }}"> AU CONTACT</button></td>
-                                            <td class="sheet-boxinputlight"><input type="number" name="attr_ATKCAC_BASE" value="0" title="@{ATKCAC_BASE} Score de base" /></td>
-                                            <td class="sheet-boxinput">
-                                                <select class="sheet-carac" name="attr_ATKCAC_CARAC" size="1" title="@{ATKCAC_CARAC}">
-                                                    <option value="@{FOR}" selected>FOR</option>
-                                                    <option value="@{DEX}">DEX</option>
-                                                    <option value="@{CON}">CON</option>
-                                                    <option value="@{INT}">INT</option>
-                                                    <option value="@{PER}">PER</option>
-                                                    <option value="@{CHA}">CHA</option>
-                                                </select>
-                                            </td>
-                                            <td class="sheet-boxinputlight"><input type="number" name="attr_ATKCAC_DIV" title="@{ATKCAC_DIV} Bonus divers" value="@{ATKCAC_BUFF}" disabled /></td>
-                                            <td class="sheet-boxinputlight"><input type="number" name="attr_ATKCAC" title="@{ATKCAC}" value="@{ATKCAC_BASE}+@{ATKCAC_CARAC}+@{ATKCAC_DIV}" disabled /></td>
-                                        </tr>
-                                        <tr>
-                                            <td class="sheet-boxtitre"><button class="sheet-boxtitre" type="roll" name="JET_TIR" title="Jet d'attaque à distance" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=&Agrave; Distance}} {{subtags=Attaque}} {{attaque=[[ @{JETNORMAL}cs20cf1[Dé] + [[@{ATKTIR}]][Bonus] ]] }}"> &Agrave; DISTANCE</button></td>
-                                            <td class="sheet-boxinputlight"><input type="number" name="attr_ATKTIR_BASE" value="0" title="@{ATKTIR_BASE} Score de base" /></td>
-                                            <td class="sheet-boxinput">
-                                                <select class="sheet-carac" name="attr_ATKTIR_CARAC" size="1" title="@{ATKTIR_CARAC}">
-                                                    <option value="@{FOR}">FOR</option>
-                                                    <option value="@{DEX}" selected>DEX</option>
-                                                    <option value="@{CON}">CON</option>
-                                                    <option value="@{INT}">INT</option>
-                                                    <option value="@{PER}">PER</option>
-                                                    <option value="@{CHA}">CHA</option>
-                                                </select>
-                                            </td>
-                                            <td class="sheet-boxinputlight"><input type="number" name="attr_ATKTIR_DIV" title="@{ATKTIR_DIV} Bonus divers" value="@{ATKTIR_BUFF}" disabled /></td>
-                                            <td class="sheet-boxinputlight"><input type="number" name="attr_ATKTIR" title="@{ATKTIR}" value="@{ATKTIR_BASE}+@{ATKTIR_CARAC}+@{ATKTIR_DIV}" disabled /></td>
-                                        </tr>
-                                        <tr>
-                                            <td class="sheet-boxtitre"><button class="sheet-boxtitre" type="roll" name="JET_PSYINFLU" title="Jet d'attaque psychique : Influence" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=Psychique (Influence)}} {{subtags=Attaque}} {{attaque=[[ @{JETNORMAL}cs20cf1[Dé] + [[@{ATKPSYINFLU}]][Bonus] ]]}}"> PSY Influence</button></td>
-                                            <td class="sheet-boxinputlight"><input type="number" name="attr_ATKPSY_BASE" value="0" title="@{ATKPSY_BASE} Score de base" /></td>
-                                            <td class="sheet-boxinput">
-                                                <select class="sheet-carac" name="attr_ATKPSYINFLU_CARAC" title="@{ATKPSYINFLU_CARAC}" size="1">
-                                                    <option value="@{FOR}">FOR</option>
-                                                    <option value="@{DEX}">DEX</option>
-                                                    <option value="@{CON}">CON</option>
-                                                    <option value="@{INT}">INT</option>
-                                                    <option value="@{PER}">PER</option>
-                                                    <option value="@{CHA}" selected>CHA</option>
-                                                </select>
-                                            </td>
-                                            <td class="sheet-boxinputlight"><input type="number" name="attr_ATKPSYINFLU_DIV" title="@{ATKPSYINFLU_DIV} Bonus divers" value="@{PSYINFLU_BUFF}" disabled /></td>
-                                            <td class="sheet-boxinputlight"><input type="number" name="attr_ATKPSYINFLU" title="@{ATKPSYINFLU}" value="@{ATKPSY_BASE}+@{ATKPSYINFLU_CARAC}+@{ATKPSYINFLU_DIV}" disabled /></td>
-                                        </tr>
-                                        <tr>
-                                            <td class="sheet-boxtitre"><button class="sheet-boxtitre" type="roll" name="JET_PSYINTUI" title="Jet d'attaque psychique : Intuition" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=Psychique (Intuition)}} {{subtags=Attaque}} {{attaque=[[ @{JETNORMAL}cs20cf1[Dé] + [[@{ATKPSYINTUI}]][Bonus] ]]}}"> PSY Intuition</button></td>
-                                            <td class="sheet-boxinputlight"><span name="attr_ATKPSY_BASE" title="@{ATKPSY_BASE} Score de base"></span></td>
-                                            <td class="sheet-boxinput">
-                                                <select class="sheet-carac" name="attr_ATKPSYINTUI_CARAC" title="@{ATKPSYINTUI_CARAC}" size="1">
-                                                    <option value="@{FOR}">FOR</option>
-                                                    <option value="@{DEX}">DEX</option>
-                                                    <option value="@{CON}">CON</option>
-                                                    <option value="@{INT}">INT</option>
-                                                    <option value="@{PER}" selected>PER</option>
-                                                    <option value="@{CHA}">CHA</option>
-                                                </select>
-                                            </td>
-                                            <td class="sheet-boxinputlight"><input type="number" name="attr_ATKPSYINTUI_DIV" title="@{ATKPSYINTUI_DIV} Bonus divers" value="@{PSYINTUI_BUFF}" disabled /></td>
-                                            <td class="sheet-boxinputlight"><input type="number" name="attr_ATKPSYINTUI" title="@{ATKPSYINTUI}" value="@{ATKPSY_BASE}+@{ATKPSYINTUI_CARAC}+@{ATKPSYINTUI_DIV}" disabled /></td>
-                                        </tr>
-                                        <tr>
-                                            <td class="sheet-boxtitre"><button class="sheet-boxtitre" type="roll" name="JET_INIT" title="Initiative" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=Initiative}} {{subtags=Combat}} {{carac=[[@{INIT}[Init.] + @{INIT_VAR}[Dé(s)] &{tracker}]]}}"> INITIATIVE</button></td>
-                                            <td>&nbsp;</td>
-                                            <td class="sheet-boxinputlight"><input type="number" name="attr_INIT_CARAC" title="@{INIT_CARAC}" value="@{DEXTERITE}" disabled /></td>
-                                            <td class="sheet-boxinputlight"><input type="number" name="attr_INIT_DIV" title="@{INIT_DIV} Bonus divers" value="@{INIT_BUFF}" disabled /></td>
-                                            <td class="sheet-boxinputlight"><input type="number" name="attr_INIT" title="@{INIT}" value="@{INIT_CARAC}+@{INIT_DIV}" disabled /></td>
-                                        </tr>
-                                        <tr><td>&nbsp;</td></tr>
-                                    </table>
-                                </td> <!-- FIN Combat -->
-                                <td style="vertical-align: top;"> <!-- PV -->
-                                    <table class="sheet-tabsep">
-                                        <tr>
-                                            <td class="sheet-textfat" colspan="2">VITALIT&Eacute;</td>
-                                        </tr>
-                                        <tr>
-                                            <td class="sheet-boxtitre"><button class="sheet-boxtitre" type="roll" name="JET_DV" title="Jet de D&eacute; de Vie" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=Dé de Vie}} {{subtags=Vitalit&eacute;}} {{DV=[[1d@{DV}[DV] + [[@{CON}]][Mod. CON] ]]}}"> DV</button></td>
-                                            <td class="sheet-boxinput">
-                                                <select class="sheet-carac" name="attr_DV" size="1" title="@{DV} D&eacute; de Vie">
-                                                    <option value="0" selected >-</option>
-                                                    <option value="4">d4</option>
-                                                    <option value="6">d6</option>
-                                                    <option value="8">d8</option>
-                                                    <option value="10">d10</option>
-                                                    <option value="12">d12</option>
-                                                </select>
-                                            </td>
-                                        </tr>
-                                        <tr>
-                                            <td class="sheet-boxtitre"><button class="sheet-boxtitre" type="roll" name="JET_RECUP" title="Jet de Récupération" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=Récupération}} {{subtags=Vitalit&eacute;}} {{RECUP=[[1d@{DV}[DV] + @{NIVEAU}[Niveau] + [[@{CON}]][Mod. CON] ]]}}"> PV</button></td>
-                                            <td class="sheet-boxinput"><input type="number" name="attr_PV_max" title="@{PV|max} Points de Vie maximum"  value="0" /></td>
-                                        </tr>
-                                        <tr>
-                                            <td  class="sheet-boxinput" COLSPAN="2">
-                                                <span class="textbase">PV restants</span>&nbsp;
-                                                <input type="number" name="attr_PV" title="@{PV} Points de Vie restants" value="0" />
-                                            </td>
-                                        </tr>
-                                        <tr>
-                                            <td  class="sheet-boxinput" COLSPAN="2">
-                                                <span class="textbase">DM temp.</span>&nbsp;
-                                                <input type="number" name="attr_DMTEMP" title="@{DMTEMP} Dommages Temporaires"  value="0" />
-                                            </td>
-                                        </tr>
-                                        <tr>
-                                            <td  class="sheet-boxinput" COLSPAN="2">
-                                                &nbsp;<input type="checkbox" name="attr_BLESSURE" title="@{BLESSURE} Gravement blessé" value="1" />
-                                                <span class="textbase">Blessure grave</span>&nbsp;
-                                                <input type="number" name="attr_SEUILBG" title="@{SEUILBG} Seuil de blessure grave" value="0" />
-                                            </td>
-                                        </tr>
-                                        <tr>
-                                            <td class="sheet-boxtitre" title="Réduction de dégâts">RD</td>
-                                            <td class="sheet-boxinput"><input type="number" name="attr_RD" title="@{RD} Réduction de dégâts" value="0" /></td>
-                                        </tr>
-                                        <tr><td>&nbsp;</td></tr>
-                                    </table>
-                                </td> <!-- FIN PV -->
-                            </tr>
-                            <tr>
-                                <td colspan="2"  style="vertical-align: top;"> <!-- Défense -->
-                                    <table class="sheet-tabsep">
-                                        <tr>
-                                            <td colspan="2" class="sheet-textfat">D&Eacute;FENSES</td>
-                                            <td class="sheet-textbase">Armure</td>
-                                            <td class="sheet-textbase">Bouclier</td>
-                                            <td class="sheet-textbase">Mod.</td>
-                                            <td class="sheet-textbase">Div.</td>
-                                            <td class="sheet-textbase">Action défensive</td>
-                                            <td class="sheet-textfat">Total</td>
-                                        </tr>
-                                        <tr>
-                                            <td class="sheet-boxtitre">DEF</td>
-                                            <td class="sheet-boxinputlight">10+</td>
-                                            <td class="sheet-boxinput"><input type="number" name="attr_DEFARMURE" title="@{DEFARMURE} Armure" value="0" /></td>
-                                            <td class="sheet-boxinput"><input type="number" name="attr_DEFBOUCLIER" title="@{DEFBOUCLIER} Bouclier" value="0" /></td>
-                                            <td class="sheet-boxinputlight"><input type="number" name="attr_DEFCAR" value="@{DEX}" title="@{DEFCAR} Modificateur de Dext&eacute;rit&eacute;" disabled /></td>
-                                            <td class="sheet-boxinputlight"><input type="number" name="attr_DEFDIV" title="@{DEFDIV} Bonus divers" value="@{DEF_BUFF}" disabled /></td>
-                                            <td class="sheet-boxinput">
-                                                <select class="sheet-carac" style="width: 80px" name="attr_DEFACT" size="1" title="@{DEFACT} Actions défensives">
-                                                    <option value="0" selected>-</option>
-                                                    <option value="2">Simple</option>
-                                                    <option value="4">Totale (L)</option>
-                                                </select>
-                                            </td>
-                                            <td class="sheet-boxinputlight"><input type="number" name="attr_DEF" value="10+@{DEFARMURE}+@{DEFBOUCLIER}+@{DEFCAR}+@{DEFDIV}+@{DEFACT}" title="@{DEF} D&eacute;fense Physique" disabled /></td>
-                                        </tr>
-                                        <tr>
-                                            <td class="sheet-boxtitre">DEP</td>
-                                            <td class="sheet-boxinputlight">10+</td>
-                                            <td class="sheet-textbase">&nbsp;</td>
-                                            <td class="sheet-textbase">&nbsp;</td>
-                                            <td class="sheet-boxinputlight"><input type="number" name="attr_DEPCAR" value="@{CHA}" title="@{DEPCAR}Modificateur de Charisme" disabled /></td>
-                                            <td class="sheet-boxinputlight"><input type="number" name="attr_DEPDIV" title="@{DEPDIV} Bonus divers" value="@{DEP_BUFF}" disabled /></td>
-                                            <td class="sheet-textbase">&nbsp;</td>
-                                            <td class="sheet-boxinputlight"><input type="number" name="attr_DEP" value="10+@{DEPCAR}+@{DEPDIV}" title="@{DEP} Défense Psychique" disabled /></td>
-                                        </tr>
-                                    </table>
-                                </td>
-                            </tr>
-                        </table>
-                    </td> <!-- FIN Combat + PV + défense -->
-                </tr>
-                <tr>
-                    <td style="vertical-align:top;"> <!-- Capa Race -->
-                        <table class="sheet-tabsep">
-                            <tr>
-                                <td class="sheet-boxinputleft">
-                                    <span class="sheet-textbasesmall">TRAITS</span><br/>
-                                    <textarea name="attr_TRAITS" title="@{TRAITS}" style="height:5em;"></textarea>
-                                </td>
-                            </tr>
-                        </table>
-                    </td> <!-- FIN Capa Race -->
-                    <td style="vertical-align:top;"> <!-- Divers -->
-                        <table class="sheet-tabsep">
-                            <tr>
-                                <td class="sheet-boxinputleft">
-                                    <span class="sheet-textbasesmall">DIVERS</span><br/>
-                                    <textarea name="attr_DIVERS" title="@{DIVERS}" style="height:5em;"></textarea>
-                                </td>
-                            </tr>
-                        </table>
-                    </td> <!-- FIN Divers -->
-                </tr>
-            </table>
-        </div> <!-- FIN Caracs + combat + PV + défense  -->
-        <img class="sheet-imghr" src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/ChroniquesGalactiques/cog_hr.png" />
-    	<div> <!-- Armes -->
-    		<table class="sheet-tabsep" title="repeating_armes">
-    			<tr>
-    				<td class="sheet-textfatleft" style="width:155px;">ARMES / ATTAQUES</td>
-    				<td class="sheet-textbase" style="width:150px;">ATTAQUE</td>
-    				<td class="sheet-textbase" style="width:20px;">CRIT.</td>
-    				<td class="sheet-textbase" style="width:185px;">DM</td>
-    				<td class="sheet-textbase" style="width:50px;">PORTÉE</td>
-    				<td class="sheet-textbase" style="widht:100%;">SPÉCIAL</td>
-    			</tr>
-    			<tr>
-    			    <td class="sheet-textbase" colspan="2">Bonus tir visé (L) :&nbsp;
-    			        <input type="checkbox" name="attr_visee_att" title="@{visee_att} Bonus de visée à l'attaque" value="@{PER}" />&nbsp;Attaque&nbsp;
-    			        <input type="checkbox" name="attr_visee_dm" title="@{visee_att} Bonus de visée aux DM" value="@{PER}" />&nbsp;DM&nbsp;
-    			    </td>
-    			    <td>&nbsp;</td>
-    			    <td class="sheet-textbase">
-    			        <input type="checkbox" name="attr_tir_hc" title="@{tir_hc} Tir haute-capacité (+1d DM)" value="1" />&nbsp;Tir Haute-capacité (L)&nbsp;
-    			    </td>
-    			</tr>
-            </table>
-            <fieldset class="repeating_armes">
-                <div class="attack">
-                    <input class="options-flag" name="attr_armeoptflag" type="checkbox" title="Montrer/cacher les options"><span>y</span>
-                    <div>
-                        <table  class="sheet-tabsep">
-                            <tr>
-                                <td>
-                                    <button type="roll" class="sheet-neutre" name="attr_jet" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=@{armenom}}} {{subtags=Attaque}} {{desc=@{armejetn}}} {{attaque=[[@{armejetd}cs>@{armecrit}cf<@{armeinct}[Dé] + [[@{armeatk}]][Attaque] + [[@{visee_att}]][Tir visé] + @{armeatkdiv}[Bonus] ]]}} {{degats=[[(@{armedmnbde}+1*@{tir_hc})d@{armedmde}@{armedmrel}@{armedmvrel}[Dé DM] + [[@{armedmcar}]][Mod.DM] + [[@{visee_dm}]][Tir visé] + @{armedmdiv}[Bonus DM] ]]}} {{special=@{armespec}}}" />
-                                </td>
-                                <td class="sheet-boxinputleft" style="min-width: 130px;">
-                                    <input type="text" name="attr_armenom" title="@{armenom}" style="font-weight: bold;" placeholder="Arme/attaque"/>
-                                </td>
-                                <td class="sheet-boxinputleft" style="min-width: 150px;">
-                                        <select class="sheet-carac" style="width: 87px;" name="attr_armeatk" title="@{armeatk}" size="1">
-                                            <option value="@{ATKCAC}" selected>CONTACT</option>
-                                            <option value="@{ATKTIR}">DISTANCE</option>
-                                            <option value="@{ATKPSYINFLU}">PSY Inf.</option>
-                                            <option value="@{ATKPSYINTUI}">PSY Int.</option>
-                                        </select>+<input type="number" style="width: 32px;" name="attr_armeatkdiv" value="0" title="@{armeatkdiv} Bonus d'attaque divers" />
-                                </td>
-                                <td class="sheet-boxinputleft" style="text-align: right;">
-                                    <input type="number" name="attr_armecrit" style="width:32px;" min="2" max="20" value="20" title="@{armecrit} Seuil de Critique (par défaut 20)" />
-                                </td>
-                                <td class="sheet-boxinputleft">
-                                    <input type="number" style="width:32px;" name="attr_armedmnbde" value="1" title="@{armedmnbde} Nombre de dés de dommage" />
-                                    <select class="sheet-carac"  style="width: 47px;" name="attr_armedmde" size="1" title="@{armedmde} Dé de dommage">
-                                        <optgroup label="Normaux">
-                                            <option value="3">d3</option>
-                                            <option value="4">d4</option>
-                                            <option value="6" selected>d6</option>
-                                            <option value="8">d8</option>
-                                            <option value="10">d10</option>
-                                            <option value="12">d12</option>
-                                        </optgroup>
-                                        <optgroup label="Sans limite">
-                                            <option value="3!">d3</option>
-                                            <option value="4!">d4</option>
-                                            <option value="6!" selected>d6</option>
-                                            <option value="8!">d8</option>
-                                            <option value="10!">d10</option>
-                                            <option value="12!">d12</option>
-                                        </optgroup>
-                                    </select>+<select class="sheet-carac" style="width: 52px;" name="attr_armedmcar" size="1" title="@{armedmcar} Modificateur aux dommages">
-                                        <option value="0">-</option>
-                                        <optgroup label="Mod. de base">
-                                            <option value="@{FOR}" selected>FOR</option>
-                                            <option value="@{DEX}">DEX</option>
-                                            <option value="@{CON}">CON</option>
-                                            <option value="@{INT}">INT</option>
-                                            <option value="@{PER}">PER</option>
-                                            <option value="@{CHA}">CHA</option>
-                                        </optgroup>
-                                        <optgroup label="Mod. de test">
-                                            <option value="@{FOR_TEST}">FOR</option>
-                                            <option value="@{DEX_TEST}">DEX</option>
-                                            <option value="@{CON_TEST}">CON</option>
-                                            <option value="@{INT_TEST}">INT</option>
-                                            <option value="@{PER_TEST}">PER</option>
-                                            <option value="@{CHA_TEST}">CHA</option>
-                                        </optgroup>
-                                    </select>+<input type="number" style="width: 32px;" name="attr_armedmdiv" value="0" title="@{armedmdiv} Bonus de dommage divers" />
-                                </td>
-                                <td class="sheet-boxinputleft" style="min-width: 50px;">
-                                    <input type="text" name="attr_armeportee" placeholder="Portée" title="@{armeportee}" />
-                                </td>
-                                <td class="sheet-boxinputleft" style="width: 100%;">
-                                    <textarea name="attr_armespec" title="@{armespec}" placeholder="Notes, capacités spéciales, effet ..." title="Notes, capacités spéciales, effet ..."></textarea>
-                                </td>
-                            </tr>
-                        </table>
+	<div class="sheet-tab-content sheet-fp1">
+		<input type="radio" name="attr_tab" class="sheet-tab sheet-tab1" value="caracs" checked="checked"><span title="Caractéristiques"></span>
+		<input type="radio" name="attr_tab" class="sheet-tab sheet-tab2" value="voies"><span title="Capacités"></span>
+		<input type="radio" name="attr_tab" class="sheet-tab sheet-tab3" value="equip"><span title="Équipement"></span>
+		<input type="radio" name="attr_tab" class="sheet-tab sheet-tab4" value="config"><span title="Configuration"></span>
+		<img class="sheet-imghr-up" src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/ChroniquesGalactiques/cog_hr.png" />
+		<div class="sheet-tab-content sheet-tab1">
+			<div> <!-- Caracs + combat + PV + défense -->
+				<table>
+					<tr>
+						<td style="width:250px; vertical-align: top;"> <!-- Caracs + Chance -->
+							<table class="sheet-tabsep"> <!-- Caracs -->
+								<tr>
+									<td class="sheet-textfat">CARAC.</td>
+									<td></td>
+									<td class="sheet-textbase">Valeur</td>
+									<td class="sheet-textfat">Mod.</td>
+									<td class="sheet-textbase">Bonus</td>
+									<td class="sheet-textfat">Test</td>
+								</tr>
+								<tr>
+									<td class="sheet-boxtitre"><button class="sheet-boxtitre" type="roll" name="JET_FOR" title="Jet de Force" value="@(togm}&{template:co1} {{perso=@{character_name}}} {{name=Force}} {{subtags=Test}} {{carac=[[@{FOR_SUP}[Dé] + [[@{FOR_TEST}]][Bonus] ]] }}"> FOR</button></td>
+									<td class="sheet-boxinputlight">
+										<select class="sheet-selectmin" name="attr_FOR_SUP" title="@{FOR_SUP} Caractéristique Normale ou Supérieure/Héroïque (règle p.138)">
+											<option value="@{JETNORMAL}" selected>N Normale</option>
+											<option value="@{JETSUP}">S Supérieure OU Héroïque</option>
+											<option value="@{JETSUPHERO}">H Supérieure ET Héroïque</option>
+										</select>
+									</td>
+									<td class="sheet-boxinput"><input type="number" name="attr_FORCE" title="@{FORCE}" value="10" min="0" /></td>
+									<td class="sheet-boxinputlight"><input type="number" name="attr_FOR" title="@{FOR}" value="floor((@{FORCE}-10)/2)" disabled /></td>
+									<td class="sheet-boxinputlight"><input type="number" name="attr_FOR_BONUS" title="@{FOR_BONUS} Bonus au Test" value="@{FOR_BUFF}" disabled /></td>
+									<td class="sheet-boxinputlight"><input type="number" name="attr_FOR_TEST" title="@{FOR_TEST}" value="@{FOR}+@{FOR_BONUS}" disabled /></td>
+								</tr>
+								<tr>
+									<td class="sheet-boxtitre"><button class="sheet-boxtitre" type="roll" name="JET_DEX" title="Jet de Dext&eacute;rit&eacute;" value="@(togm}&{template:co1} {{perso=@{character_name}}} {{name=Dext&eacute;rit&eacute;}} {{subtags=Test}} {{carac=[[@{DEX_SUP}[Dé] + [[@{DEX_TEST}]][Bonus] ]] }}"> DEX</button></td>
+									<td class="sheet-boxinputlight">
+										<select class="sheet-selectmin" name="attr_DEX_SUP" title="@{DEX_SUP} Caractéristique Normale ou Supérieure/Héroïque (règle p.138)">
+											<option value="@{JETNORMAL}" selected>N Normale</option>
+											<option value="@{JETSUP}">S Supérieure OU Héroïque</option>
+											<option value="@{JETSUPHERO}">H Supérieure ET Héroïque</option>
+										</select>
+									</td>
+									<td class="sheet-boxinput"><input type="number" name="attr_DEXTERITE" title="@{DEXTERITE}" value="10" min="0"  /></td>
+									<td class="sheet-boxinputlight"><input type="number" name="attr_DEX" title="@{DEX}" value="floor((@{DEXTERITE}-10)/2)" disabled /></td>
+									<td class="sheet-boxinputlight"><input type="number" name="attr_DEX_BONUS" title="@{DEX_BONUS} Bonus au Test" value="@{DEX_BUFF}" disabled /></td>
+									<td class="sheet-boxinputlight"><input type="number" name="attr_DEX_TEST" title="@{DEX_TEST}" value="@{DEX}+@{DEX_BONUS}" disabled /></td>
+								</tr>
+								<tr>
+									<td class="sheet-boxtitre"><button class="sheet-boxtitre" type="roll" name="JET_CON" title="Jet de Constitution" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=Constitution}} {{subtags=Test}} {{carac=[[@{CON_SUP}[Dé] + [[@{CON_TEST}]][Bonus] ]] }}"> CON</button></td>
+									<td class="sheet-boxinputlight">
+										<select class="sheet-selectmin" name="attr_CON_SUP" title="@{CON_SUP} Caractéristique Normale ou Supérieure/Héroïque (règle p.138)">
+											<option value="@{JETNORMAL}" selected>N Normale</option>
+											<option value="@{JETSUP}">S Supérieure OU Héroïque</option>
+											<option value="@{JETSUPHERO}">H Supérieure ET Héroïque</option>
+										</select>
+									</td>
+									<td class="sheet-boxinput"><input type="number" name="attr_CONSTITUTION" title="@{CONSTITUTION}" value="10" min="0"  /></td>
+									<td class="sheet-boxinputlight"><input type="number" name="attr_CON" title="@{CON}" value="floor((@{CONSTITUTION}-10)/2)" disabled /></td>
+									<td class="sheet-boxinputlight"><input type="number" name="attr_CON_BONUS" title="@{CON_BONUS} Bonus au Test" value="@{CON_BUFF}" disabled /></td>
+									<td class="sheet-boxinputlight"><input type="number" name="attr_CON_TEST" title="@{CON_TEST}" value="@{CON}+@{CON_BONUS}" disabled /></td>
+								</tr>
+								<tr>
+									<td class="sheet-boxtitre"><button class="sheet-boxtitre" type="roll" name="JET_INT" title="Jet d'Intelligence" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=Intelligence}} {{subtags=Test}} {{carac=[[@{INT_SUP}[Dé] + [[@{INT_TEST}]][Bonus] ]] }}"> INT</button></td>
+									<td class="sheet-boxinputlight">
+										<select class="sheet-selectmin" name="attr_INT_SUP" title="@{INT_SUP} Caractéristique Normale ou Supérieure/Héroïque (règle p.138)">
+											<<option value="@{JETNORMAL}" selected>N Normale</option>
+											<option value="@{JETSUP}">S Supérieure OU Héroïque</option>
+											<option value="@{JETSUPHERO}">H Supérieure ET Héroïque</option>
+										</select>
+									</td>
+									<td class="sheet-boxinput"><input type="number" name="attr_INTELLIGENCE" title="@{INTELLIGENCE}" value="10" min="0"  /></td>
+									<td class="sheet-boxinputlight"><input type="number" name="attr_INT" title="@{INT}" value="floor((@{INTELLIGENCE}-10)/2)" disabled /></td>
+									<td class="sheet-boxinputlight"><input type="number" name="attr_INT_BONUS" title="@{INT_BONUS} Bonus au Test" value="@{INT_BUFF}" disabled /></td>
+									<td class="sheet-boxinputlight"><input type="number" name="attr_INT_TEST" title="@{INT_TEST}" value="@{INT}+@{INT_BONUS}" disabled /></td>
+								</tr>
+								<tr>
+									<td class="sheet-boxtitre"><button class="sheet-boxtitre" type="roll" name="JET_PER" title="Jet de Perception" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=Perception}} {{subtags=Test}} {{carac=[[@{PER_SUP}[Dé] + [[@{PER_TEST}]][Bonus] ]] }}"> PER</button></td>
+									<td class="sheet-boxinputlight">
+										<select class="sheet-selectmin" name="attr_PER_SUP" title="@{PER_SUP} Caractéristique Normale ou Supérieure/Héroïque (règle p.138)">
+											<option value="@{JETNORMAL}" selected>N Normale</option>
+											<option value="@{JETSUP}">S Supérieure OU Héroïque</option>
+											<option value="@{JETSUPHERO}">H Supérieure ET Héroïque</option>
+										</select>
+									</td>
+									<td class="sheet-boxinput"><input type="number" name="attr_PERCEPTION" title="@{PERCEPTION}" value="10" min="0"  /></td>
+									<td class="sheet-boxinputlight"><input type="number" name="attr_PER" title="@{PER}" value="floor((@{PERCEPTION}-10)/2)" disabled /></td>
+									<td class="sheet-boxinputlight"><input type="number" name="attr_PER_BONUS" title="@{PER_BONUS} Bonus au Test" value="@{PER_BUFF}" disabled /></td>
+									<td class="sheet-boxinputlight"><input type="number" name="attr_PER_TEST" title="@{PER_TEST}" value="@{PER}+@{PER_BONUS}" disabled /></td>
+								</tr>
+								<tr>
+									<td class="sheet-boxtitre"><button class="sheet-boxtitre" type="roll" name="JET_CHA" title="Jet de Charisme" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=Charisme}} {{subtags=Test}} {{carac=[[@{CHA_SUP}[Dé] + [[@{CHA_TEST}]][Bonus] ]] }}"> CHA</button></td>
+									<td class="sheet-boxinputlight">
+										<select class="sheet-selectmin" name="attr_CHA_SUP" title="@{CHA_SUP} Caractéristique Normale ou Supérieure/Héroïque (règle p.138)">
+											<option value="@{JETNORMAL}" selected>N Normale</option>
+											<option value="@{JETSUP}">S Supérieure OU Héroïque</option>
+											<option value="@{JETSUPHERO}">H Supérieure ET Héroïque</option>
+										</select>
+									</td>
+									<td class="sheet-boxinput"><input type="number" name="attr_CHARISME" title="@{CHARISME}" value="10" min="0"  /></td>
+									<td class="sheet-boxinputlight"><input type="number" name="attr_CHA" title="@{CHA}" value="floor((@{CHARISME}-10)/2)" disabled /></td>
+									<td class="sheet-boxinputlight"><input type="number" name="attr_CHA_BONUS" title="@{CHA_BONUS} Bonus au Test" value="@{CHA_BUFF}" disabled /></td>
+									<td class="sheet-boxinputlight"><input type="number" name="attr_CHA_TEST" title="@{CHA_TEST}" value="@{CHA}+@{CHA_BONUS}" disabled /></td>
+								</tr>
+								<tr>
+									<td class="sheet-textfat" colspan="6">ÉTATS PRÉJUDICIABLES</td>
+								</tr>
+								<tr>
+									<td class="sheet-boxinputlight" colspan="6">
+										&nbsp;
+										<input type="radio" name="attr_ETATDE" value="20" title="@{ETATDE} Jet d'un d20 pour tous les tests" checked >&nbsp;Normal</input>
+										&nbsp;
+										<input type="radio" name="attr_ETATDE" value="12" title="@{ETATDE} Jet d'un d12 pour tous les tests">&nbsp;Affaibli</input>
+										&nbsp;
+										<input type="checkbox" name="attr_POISSE" title="@{POISSE} Moins bon de deux d20 pour tous les tests" value="1" />&nbsp;Poisse
+									</td>
+								</tr>
+								<tr>
+									<td class="sheet-boxinputlight" colspan="6">
+										Autres conditions :&nbsp;
+										<select class="sheet-carac" style="min-width: 100px;" name="attr_CONDITION" title="@{CONDITION}">
+											<option value="" selected>(aucune)</option>
+											<option value="A">Aveuglé</option>
+											<option value="E">Etourdi</option>
+											<option value="I">Immobilisé</option>
+											<option value="R">Renversé</option>
+											<option value="S">Surpris</option>
+										</select>
+									</td>
+								</tr>
+							</table> <!-- FIN Caracs -->
+							<table class="sheet-tabsep" style="margin-top: 20px;"> <!-- Chance -->
+								<tr>
+									<td class="sheet-boxtitre" title="Points de Chance">PC</td>
+									<td class="sheet-boxinput"><input type="number" name="attr_PC" value="0" title="@{PC} Points de Chance utilisés ou courants" /></td>
+									<td>/</td>
+									<td class="sheet-boxinput"><input type="number" name="attr_PCRACE" title="@{PCRACE}Points de Chance de Race" value="0" /></td>
+									<td>+</td>
+									<td class="sheet-boxinput"><input type="number" name="attr_PCDIV" title="@{PCDIV} Points de Chance additionnels"  value="0"/></td>
+									<td>+</td>
+									<td class="sheet-boxinputlight"><INPUT type="number" name="attr_PCCAR" value="@{CHA}" title="@{PCCAR} Modificateur de Charisme" disabled /></td>
+									<td>=</td>
+									<td class="sheet-boxinputlight"><input type="number" name="attr_PC_max" value="@{PCRACE}+@{PCDIV}+@{PCCAR}" title="@{PC|max} Points de Chance maximums" disabled /></td>
+								</tr>
+							</table> <!-- FIN Chance -->
+						</td> <!-- FIN Caracs + Chance -->
+						<td  style="width:100%; vertical-align: top;"> <!-- Combat + PV + défense -->
+							<table>
+								<tr>
+									<td style="vertical-align: top;"> <!-- Combat -->
+										<table class="sheet-tabsep">
+											<tr>
+												<td class="sheet-textfat">COMBAT</td>
+												<td class="sheet-textbase">Base</td>
+												<td class="sheet-textbase">Mod.</td>
+												<td class="sheet-textbase">Div.</td>
+												<td class="sheet-textfat">Total</td>
+											</tr>
+											<tr>
+												<td class="sheet-boxtitre"><button class="sheet-boxtitre" type="roll" name="JET_CAC" title="Jet d'attaque au contact" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=Au Contact}} {{subtags=Attaque}} {{attaque=[[@{JETNORMAL}cs20cf1[Dé] + [[@{ATKCAC}]][Bonus] ]] }}"> AU CONTACT</button></td>
+												<td class="sheet-boxinputlight"><input type="number" name="attr_ATKCAC_BASE" value="0" title="@{ATKCAC_BASE} Score de base" /></td>
+												<td class="sheet-boxinput">
+													<select class="sheet-carac" name="attr_ATKCAC_CARAC" size="1" title="@{ATKCAC_CARAC}">
+														<option value="@{FOR}" selected>FOR</option>
+														<option value="@{DEX}">DEX</option>
+														<option value="@{CON}">CON</option>
+														<option value="@{INT}">INT</option>
+														<option value="@{PER}">PER</option>
+														<option value="@{CHA}">CHA</option>
+													</select>
+												</td>
+												<td class="sheet-boxinputlight"><input type="number" name="attr_ATKCAC_DIV" title="@{ATKCAC_DIV} Bonus divers" value="@{ATKCAC_BUFF}" disabled /></td>
+												<td class="sheet-boxinputlight"><input type="number" name="attr_ATKCAC" title="@{ATKCAC}" value="@{ATKCAC_BASE}+@{ATKCAC_CARAC}+@{ATKCAC_DIV}" disabled /></td>
+											</tr>
+											<tr>
+												<td class="sheet-boxtitre"><button class="sheet-boxtitre" type="roll" name="JET_TIR" title="Jet d'attaque à distance" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=&Agrave; Distance}} {{subtags=Attaque}} {{attaque=[[@{JETNORMAL}cs20cf1[Dé] + [[@{ATKTIR}]][Bonus] ]] }}"> &Agrave; DISTANCE</button></td>
+												<td class="sheet-boxinputlight"><input type="number" name="attr_ATKTIR_BASE" value="0" title="@{ATKTIR_BASE} Score de base" /></td>
+												<td class="sheet-boxinput">
+													<select class="sheet-carac" name="attr_ATKTIR_CARAC" size="1" title="@{ATKTIR_CARAC}">
+														<option value="@{FOR}">FOR</option>
+														<option value="@{DEX}" selected>DEX</option>
+														<option value="@{CON}">CON</option>
+														<option value="@{INT}">INT</option>
+														<option value="@{PER}">PER</option>
+														<option value="@{CHA}">CHA</option>
+													</select>
+												</td>
+												<td class="sheet-boxinputlight"><input type="number" name="attr_ATKTIR_DIV" title="@{ATKTIR_DIV} Bonus divers" value="@{ATKTIR_BUFF}" disabled /></td>
+												<td class="sheet-boxinputlight"><input type="number" name="attr_ATKTIR" title="@{ATKTIR}" value="@{ATKTIR_BASE}+@{ATKTIR_CARAC}+@{ATKTIR_DIV}" disabled /></td>
+											</tr>
+											<tr>
+												<td class="sheet-boxtitre"><button class="sheet-boxtitre" type="roll" name="JET_PSYINFLU" title="Jet d'attaque psychique : Influence" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=Psychique (Influence)}} {{subtags=Attaque}} {{attaque=[[@{JETNORMAL}cs20cf1[Dé] + [[@{ATKPSYINFLU}]][Bonus] ]]}}"> PSY Influence</button></td>
+												<td class="sheet-boxinputlight"><input type="number" name="attr_ATKPSY_BASE" value="0" title="@{ATKPSY_BASE} Score de base" /></td>
+												<td class="sheet-boxinput">
+													<select class="sheet-carac" name="attr_ATKPSYINFLU_CARAC" title="@{ATKPSYINFLU_CARAC}" size="1">
+														<option value="@{FOR}">FOR</option>
+														<option value="@{DEX}">DEX</option>
+														<option value="@{CON}">CON</option>
+														<option value="@{INT}">INT</option>
+														<option value="@{PER}">PER</option>
+														<option value="@{CHA}" selected>CHA</option>
+													</select>
+												</td>
+												<td class="sheet-boxinputlight"><input type="number" name="attr_ATKPSYINFLU_DIV" title="@{ATKPSYINFLU_DIV} Bonus divers" value="@{PSYINFLU_BUFF}" disabled /></td>
+												<td class="sheet-boxinputlight"><input type="number" name="attr_ATKPSYINFLU" title="@{ATKPSYINFLU}" value="@{ATKPSY_BASE}+@{ATKPSYINFLU_CARAC}+@{ATKPSYINFLU_DIV}" disabled /></td>
+											</tr>
+											<tr>
+												<td class="sheet-boxtitre"><button class="sheet-boxtitre" type="roll" name="JET_PSYINTUI" title="Jet d'attaque psychique : Intuition" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=Psychique (Intuition)}} {{subtags=Attaque}} {{attaque=[[@{JETNORMAL}cs20cf1[Dé] + [[@{ATKPSYINTUI}]][Bonus] ]]}}"> PSY Intuition</button></td>
+												<td class="sheet-boxinputlight"><span name="attr_ATKPSY_BASE" title="@{ATKPSY_BASE} Score de base"></span></td>
+												<td class="sheet-boxinput">
+													<select class="sheet-carac" name="attr_ATKPSYINTUI_CARAC" title="@{ATKPSYINTUI_CARAC}" size="1">
+														<option value="@{FOR}">FOR</option>
+														<option value="@{DEX}">DEX</option>
+														<option value="@{CON}">CON</option>
+														<option value="@{INT}">INT</option>
+														<option value="@{PER}" selected>PER</option>
+														<option value="@{CHA}">CHA</option>
+													</select>
+												</td>
+												<td class="sheet-boxinputlight"><input type="number" name="attr_ATKPSYINTUI_DIV" title="@{ATKPSYINTUI_DIV} Bonus divers" value="@{PSYINTUI_BUFF}" disabled /></td>
+												<td class="sheet-boxinputlight"><input type="number" name="attr_ATKPSYINTUI" title="@{ATKPSYINTUI}" value="@{ATKPSY_BASE}+@{ATKPSYINTUI_CARAC}+@{ATKPSYINTUI_DIV}" disabled /></td>
+											</tr>
+											<tr>
+												<td class="sheet-boxtitre"><button class="sheet-boxtitre" type="roll" name="JET_INIT" title="Initiative" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=Initiative}} {{subtags=Combat}} {{carac=[[@{INIT}[Init.] + @{INIT_VAR}[Dé(s)] &{tracker}]]}}"> INITIATIVE</button></td>
+												<td>&nbsp;</td>
+												<td class="sheet-boxinputlight"><input type="number" name="attr_INIT_CARAC" title="@{INIT_CARAC}" value="@{DEXTERITE}" disabled /></td>
+												<td class="sheet-boxinputlight"><input type="number" name="attr_INIT_DIV" title="@{INIT_DIV} Bonus divers" value="@{INIT_BUFF}" disabled /></td>
+												<td class="sheet-boxinputlight"><input type="number" name="attr_INIT" title="@{INIT}" value="@{INIT_CARAC}+@{INIT_DIV}" disabled /></td>
+											</tr>
+											<tr><td>&nbsp;</td></tr>
+										</table>
+									</td> <!-- FIN Combat -->
+									<td style="vertical-align: top;"> <!-- PV -->
+										<table class="sheet-tabsep">
+											<tr>
+												<td class="sheet-textfat" colspan="2">VITALIT&Eacute;</td>
+											</tr>
+											<tr>
+												<td class="sheet-boxtitre"><button class="sheet-boxtitre" type="roll" name="JET_DV" title="Jet de D&eacute; de Vie" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=Dé de Vie}} {{subtags=Vitalit&eacute;}} {{DV=[[1d@{DV}[DV] + [[@{CON}]][Mod. CON] ]]}}"> DV</button></td>
+												<td class="sheet-boxinput">
+													<select class="sheet-carac" name="attr_DV" size="1" title="@{DV} D&eacute; de Vie">
+														<option value="0" selected >-</option>
+														<option value="4">d4</option>
+														<option value="6">d6</option>
+														<option value="8">d8</option>
+														<option value="10">d10</option>
+														<option value="12">d12</option>
+													</select>
+												</td>
+											</tr>
+											<tr>
+												<td class="sheet-boxtitre"><button class="sheet-boxtitre" type="roll" name="JET_RECUP" title="Jet de Récupération" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=Récupération}} {{subtags=Vitalit&eacute;}} {{RECUP=[[1d@{DV}[DV] + @{NIVEAU}[Niveau] + [[@{CON}]][Mod. CON] ]]}}"> PV</button></td>
+												<td class="sheet-boxinput"><input type="number" name="attr_PV_max" title="@{PV|max} Points de Vie maximum"  value="0" /></td>
+											</tr>
+											<tr>
+												<td  class="sheet-boxinput" COLSPAN="2">
+													<span class="textbase">PV restants</span>&nbsp;
+													<input type="number" name="attr_PV" title="@{PV} Points de Vie restants" value="0" />
+												</td>
+											</tr>
+											<tr>
+												<td  class="sheet-boxinput" COLSPAN="2">
+													<span class="textbase">DM temp.</span>&nbsp;
+													<input type="number" name="attr_DMTEMP" title="@{DMTEMP} Dommages Temporaires"  value="0" />
+												</td>
+											</tr>
+											<tr>
+												<td  class="sheet-boxinput" COLSPAN="2">
+													&nbsp;<input type="checkbox" name="attr_BLESSURE" title="@{BLESSURE} Gravement blessé" value="1" />
+													<span class="textbase">Blessure grave</span>&nbsp;
+													<input type="number" name="attr_SEUILBG" title="@{SEUILBG} Seuil de blessure grave" value="0" />
+												</td>
+											</tr>
+											<tr>
+												<td class="sheet-boxtitre" title="Réduction de dégâts">RD</td>
+												<td class="sheet-boxinput"><input type="number" name="attr_RD" title="@{RD} Réduction de dégâts" value="0" /></td>
+											</tr>
+											<tr><td>&nbsp;</td></tr>
+										</table>
+									</td> <!-- FIN PV -->
+								</tr>
+								<tr>
+									<td colspan="2"  style="vertical-align: top;"> <!-- Défense -->
+										<table class="sheet-tabsep">
+											<tr>
+												<td colspan="2" class="sheet-textfat">D&Eacute;FENSES</td>
+												<td class="sheet-textbase">Armure</td>
+												<td class="sheet-textbase">Bouclier</td>
+												<td class="sheet-textbase">Mod.</td>
+												<td class="sheet-textbase">Div.</td>
+												<td class="sheet-textbase">Action défensive</td>
+												<td class="sheet-textfat">Total</td>
+											</tr>
+											<tr>
+												<td class="sheet-boxtitre">DEF</td>
+												<td class="sheet-boxinputlight">10+</td>
+												<td class="sheet-boxinput"><input type="number" name="attr_DEFARMURE" title="@{DEFARMURE} Armure" value="0" /></td>
+												<td class="sheet-boxinput"><input type="number" name="attr_DEFBOUCLIER" title="@{DEFBOUCLIER} Bouclier" value="0" /></td>
+												<td class="sheet-boxinputlight"><input type="number" name="attr_DEFCAR" value="@{DEX}" title="@{DEFCAR} Modificateur de Dext&eacute;rit&eacute;" disabled /></td>
+												<td class="sheet-boxinputlight"><input type="number" name="attr_DEFDIV" title="@{DEFDIV} Bonus divers" value="@{DEF_BUFF}" disabled /></td>
+												<td class="sheet-boxinput">
+													<select class="sheet-carac" style="width: 80px" name="attr_DEFACT" size="1" title="@{DEFACT} Actions défensives">
+														<option value="0" selected>-</option>
+														<option value="2">Simple</option>
+														<option value="4">Totale (L)</option>
+													</select>
+												</td>
+												<td class="sheet-boxinputlight"><input type="number" name="attr_DEF" value="10+@{DEFARMURE}+@{DEFBOUCLIER}+@{DEFCAR}+@{DEFDIV}+@{DEFACT}" title="@{DEF} D&eacute;fense Physique" disabled /></td>
+											</tr>
+											<tr>
+												<td class="sheet-boxtitre">DEP</td>
+												<td class="sheet-boxinputlight">10+</td>
+												<td class="sheet-textbase">&nbsp;</td>
+												<td class="sheet-textbase">&nbsp;</td>
+												<td class="sheet-boxinputlight"><input type="number" name="attr_DEPCAR" value="@{CHA}" title="@{DEPCAR}Modificateur de Charisme" disabled /></td>
+												<td class="sheet-boxinputlight"><input type="number" name="attr_DEPDIV" title="@{DEPDIV} Bonus divers" value="@{DEP_BUFF}" disabled /></td>
+												<td class="sheet-textbase">&nbsp;</td>
+												<td class="sheet-boxinputlight"><input type="number" name="attr_DEP" value="10+@{DEPCAR}+@{DEPDIV}" title="@{DEP} Défense Psychique" disabled /></td>
+											</tr>
+										</table>
+									</td>
+								</tr>
+							</table>
+						</td> <!-- FIN Combat + PV + défense -->
+					</tr>
+					<tr>
+						<td style="vertical-align:top;"> <!-- Capa Race -->
+							<table class="sheet-tabsep">
+								<tr>
+									<td class="sheet-boxinputleft">
+										<span class="sheet-textbasesmall">TRAITS</span><br/>
+										<textarea name="attr_TRAITS" title="@{TRAITS}" style="height:5em;"></textarea>
+									</td>
+								</tr>
+							</table>
+						</td> <!-- FIN Capa Race -->
+						<td style="vertical-align:top;"> <!-- Divers -->
+							<table class="sheet-tabsep">
+								<tr>
+									<td class="sheet-boxinputleft">
+										<span class="sheet-textbasesmall">DIVERS</span><br/>
+										<textarea name="attr_DIVERS" title="@{DIVERS}" style="height:5em;"></textarea>
+									</td>
+								</tr>
+							</table>
+						</td> <!-- FIN Divers -->
+					</tr>
+				</table>
+			</div> <!-- FIN Caracs + combat + PV + défense  -->
+			<img class="sheet-imghr" src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/ChroniquesGalactiques/cog_hr.png" />
+			<div> <!-- Armes -->
+				<table class="sheet-tabsep" title="repeating_armes">
+					<tr>
+						<td class="sheet-textfatleft" style="width:155px;">ARMES / ATTAQUES</td>
+						<td class="sheet-textbase" style="width:150px;">ATTAQUE</td>
+						<td class="sheet-textbase" style="width:20px;">CRIT.</td>
+						<td class="sheet-textbase" style="width:185px;">DM</td>
+						<td class="sheet-textbase" style="width:50px;">PORTÉE</td>
+						<td class="sheet-textbase" style="widht:100%;">SPÉCIAL</td>
+					</tr>
+					<tr>
+						<td class="sheet-textbase" colspan="2">Bonus tir visé (L) :&nbsp;
+							<input type="checkbox" name="attr_visee_att" title="@{visee_att} Bonus de visée à l'attaque" value="@{PER}" />&nbsp;Attaque&nbsp;
+							<input type="checkbox" name="attr_visee_dm" title="@{visee_att} Bonus de visée aux DM" value="@{PER}" />&nbsp;DM&nbsp;
+						</td>
+						<td>&nbsp;</td>
+						<td class="sheet-textbase">
+							<input type="checkbox" name="attr_tir_hc" title="@{tir_hc} Tir haute-capacité (+1d DM)" value="1" />&nbsp;Tir Haute-capacité (L)&nbsp;
+						</td>
+					</tr>
+				</table>
+				<fieldset class="repeating_armes">
+					<div class="attack">
+						<input class="options-flag" name="attr_armeoptflag" type="checkbox" title="Montrer/cacher les options"><span>y</span>
+						<div>
+							<table  class="sheet-tabsep">
+								<tr>
+									<td>
+										<button type="roll" class="sheet-neutre" name="attr_jet" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=@{armenom}}} {{subtags=Attaque}} {{desc=@{armejetn}}} {{attaque=[[@{armejetd}cs>@{armecrit}cf<@{armeinct}[Dé] + [[@{armeatk}]][Attaque] + [[@{visee_att}]][Tir visé] + @{armeatkdiv}[Bonus] ]]}} {{degats=[[(@{armedmnbde}+1*@{tir_hc})d@{armedmde}@{armedmrel}@{armedmvrel}[Dé DM] + [[@{armedmcar}]][Mod.DM] + [[@{visee_dm}]][Tir visé] + @{armedmdiv}[Bonus DM] ]]}} {{special=@{armespec}}}" />
+									</td>
+									<td class="sheet-boxinputleft" style="min-width: 130px;">
+										<input type="text" name="attr_armenom" title="@{armenom}" style="font-weight: bold;" placeholder="Arme/attaque"/>
+									</td>
+									<td class="sheet-boxinputleft" style="min-width: 150px;">
+											<select class="sheet-carac" style="width: 87px;" name="attr_armeatk" title="@{armeatk}" size="1">
+												<option value="@{ATKCAC}" selected>CONTACT</option>
+												<option value="@{ATKTIR}">DISTANCE</option>
+												<option value="@{ATKPSYINFLU}">PSY Inf.</option>
+												<option value="@{ATKPSYINTUI}">PSY Int.</option>
+											</select>+<input type="number" style="width: 32px;" name="attr_armeatkdiv" value="0" title="@{armeatkdiv} Bonus d'attaque divers" />
+									</td>
+									<td class="sheet-boxinputleft" style="text-align: right;">
+										<input type="number" name="attr_armecrit" style="width:32px;" min="2" max="20" value="20" title="@{armecrit} Seuil de Critique (par défaut 20)" />
+									</td>
+									<td class="sheet-boxinputleft">
+										<input type="number" style="width:32px;" name="attr_armedmnbde" value="1" title="@{armedmnbde} Nombre de dés de dommage" />
+										<select class="sheet-carac"  style="width: 47px;" name="attr_armedmde" size="1" title="@{armedmde} Dé de dommage">
+											<optgroup label="Normaux">
+												<option value="3">d3</option>
+												<option value="4">d4</option>
+												<option value="6" selected>d6</option>
+												<option value="8">d8</option>
+												<option value="10">d10</option>
+												<option value="12">d12</option>
+											</optgroup>
+											<optgroup label="Sans limite">
+												<option value="3!">d3</option>
+												<option value="4!">d4</option>
+												<option value="6!" selected>d6</option>
+												<option value="8!">d8</option>
+												<option value="10!">d10</option>
+												<option value="12!">d12</option>
+											</optgroup>
+										</select>+<select class="sheet-carac" style="width: 52px;" name="attr_armedmcar" size="1" title="@{armedmcar} Modificateur aux dommages">
+											<option value="0">-</option>
+											<optgroup label="Mod. de base">
+												<option value="@{FOR}" selected>FOR</option>
+												<option value="@{DEX}">DEX</option>
+												<option value="@{CON}">CON</option>
+												<option value="@{INT}">INT</option>
+												<option value="@{PER}">PER</option>
+												<option value="@{CHA}">CHA</option>
+											</optgroup>
+											<optgroup label="Mod. de test">
+												<option value="@{FOR_TEST}">FOR</option>
+												<option value="@{DEX_TEST}">DEX</option>
+												<option value="@{CON_TEST}">CON</option>
+												<option value="@{INT_TEST}">INT</option>
+												<option value="@{PER_TEST}">PER</option>
+												<option value="@{CHA_TEST}">CHA</option>
+											</optgroup>
+										</select>+<input type="number" style="width: 32px;" name="attr_armedmdiv" value="0" title="@{armedmdiv} Bonus de dommage divers" />
+									</td>
+									<td class="sheet-boxinputleft" style="min-width: 50px;">
+										<input type="text" name="attr_armeportee" placeholder="Portée" title="@{armeportee}" />
+									</td>
+									<td class="sheet-boxinputleft" style="width: 100%;">
+										<textarea name="attr_armespec" title="@{armespec}" placeholder="Notes, capacités spéciales, effet ..." title="Notes, capacités spéciales, effet ..."></textarea>
+									</td>
+								</tr>
+							</table>
+						</div>
+						<div class="options">
+							<table class="sheet-tabsep">
+								<tr>
+									<td style="width: 18px;">&nbsp;</td>
+									<td class="sheet-boxinputleft" style="width: 130px;">
+										<input type="text" name="attr_armejetn" style="font-weight: bold;" placeholder="Nom de l'attaque" title="@{armejetn}" />
+									</td>
+									<td class="sheet-boxinputleft" style="width: 150px;">&nbsp;Type de jet
+										<select class="sheet-carac" style="width: 65px;" name="attr_armejetd" size="1" title="@{armejetd} Jet d'attaque : 'Risque' = avec d12, 'Expert' = meilleur de deux d20">
+											<option value="@{JETNORMAL}" selected>Normal</option>
+											<option value="@{JETRISQUE}">Risque (d12)</option>
+											<option value="@{JETSUP}">Expert (2 d20)</option>
+										</select>
+									</td>
+									<td class="sheet-boxinputleft" style="width: 32px;">
+										<input type="number" style="width: 32px;" name="attr_armeinct" min="1" max="19" value="1" title="@{armeinct} Seuil d'incident de tir (par défaut 1)" />
+									</td>
+									<td class="sheet-boxinputleft" style="width: 188px;">
+										<select class="sheet-carac" style="width: 110px;" name="attr_armedmrel" size="1" title="@{armedmrel} Relance dés de DM = (r)eroll -- 1 fois = (r)eroll (o)nce">
+											<option value="" selected>-</option>
+											<option value="r">Relance DM</option>
+											<option value="ro">Relance DM (1 fois)</option>
+										</select>
+										<input type="text" style="width: 70px;" name="attr_armedmvrel" title="@{armedmvrel} Seuil de relance (relance les 1 si non indiqué)" />
+									</td>
+									<td>&nbsp;</td>
+									<td>&nbsp;</td>
+								</tr>
+							</table>
+						</div>
+					</div>
+				</fieldset>
+			</div>
+			<img class="sheet-imghr" src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/ChroniquesGalactiques/cog_hr.png" />
+		</div>
+		<div class="sheet-tab-content sheet-tab2">
+			<div> <!-- Voies -->
+				<table>
+					<tr><td class="sheet-textfatleft" COLSPAN="5">CAPACIT&Eacute;S DU PERSONNAGE</td></tr>
+					<tr>
+						<td class="sheet-boxtitresmall" style="width: 20px;">&nbsp;</td>
+						<td class="sheet-boxtitresmall">Voie 1</td>
+						<td class="sheet-boxtitresmall">Voie 2</td>
+						<td class="sheet-boxtitresmall">Voie 3</td>
+					</tr>
+					<tr>
+						<td class="sheet-boxtitresmall">R</td>
+						<td class="sheet-boxinputleft"><input type="text" style="font-weight: bold;text-align: center;" name="attr_voie1nom" title="@{voie1nom}" placeholder="Nom de la Voie n°1" /></td>
+						<td class="sheet-boxinput"><input type="text" style="font-weight: bold;text-align: center;" name="attr_voie2nom" placeholder="Nom de la Voie n°2" /></td>
+						<td class="sheet-boxinput"><input type="text" style="font-weight: bold;text-align: center;" name="attr_voie3nom" placeholder="Nom de la Voie n°3" /></td>
+					</tr>
+					<tr>
+						<td class="sheet-boxtitresmall">1</td>
+						<td class="sheet-boxvoie"><textarea name="attr_voie1-1" title="@{voie1-1}"></textarea></td>
+						<td class="sheet-boxvoie"><textarea name="attr_voie2-1"></textarea></td>
+						<td class="sheet-boxvoie"><textarea name="attr_voie3-1"></textarea></td>
+					</tr>
+					<tr>
+						<td class="sheet-boxtitresmall">2</td>
+						<td class="sheet-boxvoie"><textarea name="attr_voie1-2" title="@{voie1-2}"></textarea></td>
+						<td class="sheet-boxvoie"><textarea name="attr_voie2-2"></textarea></td>
+						<td class="sheet-boxvoie"><textarea name="attr_voie3-2"></textarea></td>
+					</tr>
+					<tr>
+						<td class="sheet-boxtitresmall">3</td>
+						<td class="sheet-boxvoie"><textarea name="attr_voie1-3" title="@{voie1-3}"></textarea></td>
+						<td class="sheet-boxvoie"><textarea name="attr_voie2-3"></textarea></td>
+						<td class="sheet-boxvoie"><textarea name="attr_voie3-3"></textarea></td>
+					</tr>
+					<tr>
+						<td class="sheet-boxtitresmall">4</td>
+						<td class="sheet-boxvoie"><textarea name="attr_voie1-4" title="@{voie1-4}"></textarea></td>
+						<td class="sheet-boxvoie"><textarea name="attr_voie2-4"></textarea></td>
+						<td class="sheet-boxvoie"><textarea name="attr_voie3-4"></textarea></td>
+					</tr>
+					<tr>
+						<td class="sheet-boxtitresmall">5</td>
+						<td class="sheet-boxvoie"><textarea name="attr_voie1-5"title="@{voie1-5}"></textarea></td>
+						<td class="sheet-boxvoie"><textarea name="attr_voie2-5"></textarea></td>
+						<td class="sheet-boxvoie"><textarea name="attr_voie3-5"></textarea></td>
+					</tr>
+				</table>
+				<table>
+					<tr>
+						<td class="sheet-boxtitresmall" style="width: 20px;">&nbsp;</td>
+						<td class="sheet-boxtitresmall">Voie 4</td>
+						<td class="sheet-boxtitresmall">Voie 5</td>
+						<td class="sheet-boxtitresmall">Voie 6</td>
+					</tr>
+					<tr>
+						<td class="sheet-boxtitresmall">R</td>
+						<td class="sheet-boxinputleft"><input type="text" style="font-weight: bold;text-align: center;" name="attr_voie4nom" placeholder="Nom de la Voie n°4" /></td>
+						<td class="sheet-boxinput"><input type="text" style="font-weight: bold;text-align: center;" name="attr_voie5nom" placeholder="Nom de la Voie n°5" /></td>
+						<td class="sheet-boxinput"><input type="text" style="font-weight: bold;text-align: center;" name="attr_voie6nom" placeholder="Nom de la Voie n°6" /></td>
+					</tr>
+					<tr>
+						<td class="sheet-boxtitresmall">1</td>
+						<td class="sheet-boxvoie"><textarea name="attr_voie4-1"></textarea></td>
+						<td class="sheet-boxvoie"><textarea name="attr_voie5-1"></textarea></td>
+						<td class="sheet-boxvoie"><textarea name="attr_voie6-1"></textarea></td>
+					</tr>
+					<tr>
+						<td class="sheet-boxtitresmall">2</td>
+						<td class="sheet-boxvoie"><textarea name="attr_voie4-2"></textarea></td>
+						<td class="sheet-boxvoie"><textarea name="attr_voie5-2"></textarea></td>
+						<td class="sheet-boxvoie"><textarea name="attr_voie6-2"></textarea></td>
+					</tr>
+					<tr>
+						<td class="sheet-boxtitresmall">3</td>
+						<td class="sheet-boxvoie"><textarea name="attr_voie4-3"></textarea></td>
+						<td class="sheet-boxvoie"><textarea name="attr_voie5-3"></textarea></td>
+						<td class="sheet-boxvoie"><textarea name="attr_voie6-3"></textarea></td>
+					</tr>
+					<tr>
+						<td class="sheet-boxtitresmall">4</td>
+						<td class="sheet-boxvoie"><textarea name="attr_voie4-4"></textarea></td>
+						<td class="sheet-boxvoie"><textarea name="attr_voie5-4"></textarea></td>
+						<td class="sheet-boxvoie"><textarea name="attr_voie6-4"></textarea></td>
+					</tr>
+					<tr>
+						<td class="sheet-boxtitresmall">5</td>
+						<td class="sheet-boxvoie"><textarea name="attr_voie4-5"></textarea></td>
+						<td class="sheet-boxvoie"><textarea name="attr_voie5-5"></textarea></td>
+						<td class="sheet-boxvoie"><textarea name="attr_voie6-5"></textarea></td>
+					</tr>
+				</table>
+				<div>
+					<input type="checkbox" class="sheet-block-switch" name="attr_voies789" title="@{voies789}" value="1"><span>Plus de voies</span>
+					<div class="sheet-block-hidden"></div>
+					<div class="sheet-block-show">
+						<table>
+							<tr>
+								<td class="sheet-boxtitresmall" style="width: 20px;">&nbsp;</td>
+								<td class="sheet-boxtitresmall">Voie 7</td>
+								<td class="sheet-boxtitresmall">Voie 8</td>
+								<td class="sheet-boxtitresmall">Voie 9</td>
+							</tr>
+							<tr>
+								<td class="sheet-boxtitresmall">R</td>
+								<td class="sheet-boxinputleft"><input type="text" style="font-weight: bold;text-align: center;" name="attr_voie7nom" placeholder="Nom de la Voie n°7" /></td>
+								<td class="sheet-boxinput"><input type="text" style="font-weight: bold;text-align: center;" name="attr_voie8nom" placeholder="Nom de la Voie n°8" /></td>
+								<td class="sheet-boxinput"><input type="text" style="font-weight: bold;text-align: center;" name="attr_voie9nom" placeholder="Nom de la Voie n°9" /></td>
+							</tr>
+							<tr>
+								<td class="sheet-boxtitresmall">1</td>
+								<td class="sheet-boxvoie"><textarea name="attr_voie7-1"></textarea></td>
+								<td class="sheet-boxvoie"><textarea name="attr_voie8-1"></textarea></td>
+								<td class="sheet-boxvoie"><textarea name="attr_voie9-1"></textarea></td>
+							</tr>
+							<tr>
+								<td class="sheet-boxtitresmall">2</td>
+								<td class="sheet-boxvoie"><textarea name="attr_voie7-2"></textarea></td>
+								<td class="sheet-boxvoie"><textarea name="attr_voie8-2"></textarea></td>
+								<td class="sheet-boxvoie"><textarea name="attr_voie9-2"></textarea></td>
+							</tr>
+							<tr>
+								<td class="sheet-boxtitresmall">3</td>
+								<td class="sheet-boxvoie"><textarea name="attr_voie7-3"></textarea></td>
+								<td class="sheet-boxvoie"><textarea name="attr_voie8-3"></textarea></td>
+								<td class="sheet-boxvoie"><textarea name="attr_voie9-3"></textarea></td>
+							</tr>
+							<tr>
+								<td class="sheet-boxtitresmall">4</td>
+								<td class="sheet-boxvoie"><textarea name="attr_voie7-4"></textarea></td>
+								<td class="sheet-boxvoie"><textarea name="attr_voie8-4"></textarea></td>
+								<td class="sheet-boxvoie"><textarea name="attr_voie9-4"></textarea></td>
+							</tr>
+							<tr>
+								<td class="sheet-boxtitresmall">5</td>
+								<td class="sheet-boxvoie"><textarea name="attr_voie7-5"></textarea></td>
+								<td class="sheet-boxvoie"><textarea name="attr_voie8-5"></textarea></td>
+								<td class="sheet-boxvoie"><textarea name="attr_voie9-5"></textarea></td>
+							</tr>
+						</table>
+					</div>
+				</div>
+				<img class="sheet-imghr" src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/ChroniquesGalactiques/cog_hr.png" />
+				<table class="sheet-tabsep" title="repeating_jetcapas">
+					<tr>
+						<td class="sheet-textfatleft" style="min-width:245px;">Jets de Capacités</td>
+						<td class="sheet-textbase" style="width:100%;">&nbsp;</td>
+					</tr>
+				</table>
+				<fieldset class="repeating_jetcapas">
+					<table  class="sheet-tabsep">
+						<tr>
+							<td>
+								<button type="roll" class="sheet-neutre" name="attr_jet" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=@{jetcapanom}}} {{subtags=Capacité}} {{carac=[[@{jetcapanbde}d@{jetcapade}@{jetcapatypjet} + [[@{jetcapacarac}]] + @{jetcapadiv}]] }} {{desc=@{jetcapadesc}}}" />
+							</td>
+							<td class="sheet-boxinputleft" style="min-width:200px;">
+								<input type="text" name="attr_jetcapanom" title="@{jetcapanom}" style="font-weight: bold;" placeholder="Nom du Jet de capacité" />
+							</td>
+							<td class="sheet-textbase"  style="text-align: right;">
+								Jet
+							</td>
+							<td class="sheet-boxinputleft">
+								<input type="number" style="width:32px;" name="attr_jetcapanbde" value="1" title="@{jetcapanbde} Nombre de dés" />
+								<select class="sheet-carac"  style="width:50px;" name="attr_jetcapade" size="1" title="@{jetcapade} Dé (d20 => d12 si Affaibli)">
+									<option value="4">d4</option>
+									<option value="6">d6</option>
+									<option value="8">d8</option>
+									<option value="10">d10</option>
+									<option value="12">d12</option>
+									<option value="@{ETATDE}" selected>d20 (ou d12 si Affaibli)</option>
+								</select>
+								(<select class="sheet-carac" style="width:30px;" name="attr_jetcapatypjet" size="1" title="@{jetcapatypjet} Option du jet : normal, meilleur dé, moins bon dé, sans limite">
+									<option value="">N - Normal</option>
+									<option value="kh1">S - Garder le meilleur dé</option>
+									<option value="kl1">I - Garder le moins bon dé</option>
+									<option value="!">E - Explosif (jet sans limite)</option>
+								</select>)
+								+<select class="sheet-carac" style="width:50px;" name="attr_jetcapacarac" size="1" title="@{jetcapacarac} Modificateur du jet">
+									<option value="0">-</option>
+									<optgroup label="Mod. de base">
+										<option value="@{FOR}" selected>FOR</option>
+										<option value="@{DEX}">DEX</option>
+										<option value="@{CON}">CON</option>
+										<option value="@{INT}">INT</option>
+										<option value="@{PER}">PER</option>
+										<option value="@{CHA}">CHA</option>
+									</optgroup>
+									<optgroup label="Mod. de test">
+										<option value="@{FOR_TEST}">FOR</option>
+										<option value="@{DEX_TEST}">DEX</option>
+										<option value="@{CON_TEST}">CON</option>
+										<option value="@{INT_TEST}">INT</option>
+										<option value="@{PER_TEST}">PER</option>
+										<option value="@{CHA_TEST}">CHA</option>
+									</optgroup>
+									<optgroup label="Attaques">
+										<option value="@{ATKCAC}">ATC</option>
+										<option value="@{ATKTIR}">ATD</option>
+										<option value="@{ATKPSYINFLU}">Influ. Psy</option>
+										<option value="@{ATKPSYINTUI}">Intui. Psy</option>
+									</optgroup>
+								</select>+<input type="number" style="width:32px;" name="attr_jetcapadiv" value="0" title="@{jetcapadiv} Bonus divers" />
+							</td>
+							<td class="sheet-textbase"  style="text-align: right;">
+								Desc.
+							</td>
+							<td class="sheet-boxinputleft" style="width:100%;">
+								<textarea name="attr_jetcapadesc" placeholder="Description" title="@{jetcapadesc}"></textarea>
+							</td>
+						</tr>
+					</table>
+				</fieldset>
+			</div> <!-- FIN Voies -->
+			<img class="sheet-imghr" src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/ChroniquesGalactiques/cog_hr.png" />
+			<div>
+				<input type="checkbox" class="sheet-block-switch" name="attr_voir_traits"><span class="sheet-textbase">Autres traits</span>
+				<div class="sheet-block-hidden"></div>
+				<div class="sheet-block-show">
+					<fieldset class="repeating_traits">
+						<table class="sheet-tabsep">
+							<tr>
+								<td style="width: 15px;">
+									<button type="roll" name="attr_chat" class="sheet-output" value='/w "@{character_name}" &{template:co1} {{perso=@{character_name}}} {{name=@{traitnom}}} {{subtags=@{traittype}}} {{text=@{traitdesc}}}'>w</button>
+								</td>
+								<td class="sheet-boxinputleft" style="width: 200px;"><input type="text" style="font-weight: bold;" name="attr_traitnom" placeholder="Nom du trait" title="@{traitnom}" /></td>
+								<td class="sheet-boxinputleft" style="width: 150px;"><input type="text" name="attr_traittype" placeholder="Origine/Type de trait" title="@{traittype}" /></td>
+								<td class="sheet-boxinputleft"><textarea name="attr_traitdesc" placeholder="Description" title="@{traitdesc}"></textarea></td>
+							</tr>
+						</table>
+					</fieldset>
+					<img class="sheet-imghr" src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/ChroniquesOublieesContemporain/coc_hr.jpg" />
+				</div>
+			</div>
+		</div>
+		<div class="sheet-tab-content sheet-tab3">
+			<div> <!-- Equipement et règles optionnelles -->
+				<div class="sheet-2colrow">
+					<div class="sheet-col" title="repeating_equipement">
+						<div class="sheet-boxtitre">&Eacute;QUIPEMENT : Consommables</div>
+						<div class="sheet-boxinputleft">
+							<span class="textbase">Crédits&nbsp;:</span>&nbsp;
+							<input type="text" style="width:320px;" name="attr_RICHESSE" title="@{RICHESSE}" placeholder="Rien ? C'est la pauvret&eacute; !" />
+						</div>
+						<fieldset class="repeating_equipement">
+							<div class="sheet-boxvoie">
+								<input type="text" style="width:310px;" name="attr_equip-nom" title="@{equip-nom}" />
+								&nbsp;<span class="sheet-textbase">Qt&eacute;</span>
+								<input type="number" name="attr_equip-qte" value="1" title="@{equip-qte}" />
+							</div>
+						</fieldset>
+					</div>
+					<div class="sheet-col" title="repeating_materiel">
+						<div class="sheet-boxtitre">&Eacute;QUIPEMENT : Personnel</div>
+						<fieldset class="repeating_materiel">
+							<div class="sheet-boxvoie">
+								<input type="text" name="attr_mater-nom" title="@{mater-nom}" />
+							</div>
+						</fieldset>
+					</div>
+				</div>
+				<img class="sheet-imghr" src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/ChroniquesGalactiques/cog_hr.png" />
+				<div class="sheet-2colrow">
+					<div class="sheet-col">
+						<table>
+							<tr><td class="sheet-boxtitre">&Eacute;QUIPEMENT : Divers</td></tr>
+							<tr><td class="sheet-boxinputleft"><textarea name="attr_equip-div" style="height:15em;" title="@{equip-div}"></textarea></td></tr>
+						</table>
+					</div>
+					<div class="sheet-col">
+						<table>
+							<tr><td class="sheet-boxtitre">Notes</td></tr>
+							<tr><td class="sheet-boxinputleft"><textarea name="attr_notes" style="height:15em;" title="@{notes}"></textarea></td></tr>
+						</table>
+					</div>
+				</div>
+				<img class="sheet-imghr" src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/ChroniquesGalactiques/cog_hr.png" />    
+			</div> <!-- FIN Equipement et règles optionnelles -->
+		</div>
+		<div class="sheet-tab-content sheet-tab4">
+			<div class="sheet-row"> <!-- Config -->
+				<table class="sheet-tabsep">
+					<tr>
+						<td style="width: 15%;">
+							<span class="textbase">Jets</span>&nbsp;
+							<select class="sheet-carac" style="width: 75px;" name="attr_togm" title="@{togm}" size="1">
+								<option value="" selected>Normaux</option>
+								<option value="/w gm ">Cachés</option>
+							</select>
+						</td>
+						<td style="width: 20%;">
+							<span class="textbase">Initiative variable</span>&nbsp;<input type="checkbox" name="attr_INIT_VAR" title="@{INIT_VAR}" value="[[1d6!]]" />
+						</td>
+						<td style="width: 25%;"></td>
+						<td style="width: 20%;"></td>
+						<td style="width: 20%;"></td>
+					</tr>
+				</table>
+			</div> <!-- FIN Config -->
+			<img class="sheet-imghr" src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/ChroniquesGalactiques/cog_hr.png" />
+			<div class="sheet-row"> <!-- BUFFS -->
+				<div class="sheet-textfatleft">BUFFS</div>
+				<table class="sheet-tabsep">
+					<tr>
+						<td style="width: 5%;">FOR:</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_FOR_BUFF1_DESC" /><input class="sheet-buff" type="number" name="attr_FOR_BUFF1" />
+						</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_FOR_BUFF2_DESC" /><input class="sheet-buff" type="number" name="attr_FOR_BUFF2" />
+						</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_FOR_BUFF3_DESC" /><input class="sheet-buff" type="number" name="attr_FOR_BUFF3" />
+						</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_FOR_BUFF4_DESC" /><input class="sheet-buff" type="number" name="attr_FOR_BUFF4" />
+						</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_FOR_BUFF5_DESC" /><input class="sheet-buff" type="number" name="attr_FOR_BUFF5" />
+						</td>
+					</tr>
+					<tr>
+						<td style="width: 5%;">DEX:</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_DEX_BUFF1_DESC" /><input class="sheet-buff" type="number" name="attr_DEX_BUFF1" />
+						</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_DEX_BUFF2_DESC" /><input class="sheet-buff" type="number" name="attr_DEX_BUFF2" />
+						</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_DEX_BUFF3_DESC" /><input class="sheet-buff" type="number" name="attr_DEX_BUFF3" />
+						</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_DEX_BUFF4_DESC" /><input class="sheet-buff" type="number" name="attr_DEX_BUFF4" />
+						</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_DEX_BUFF5_DESC" /><input class="sheet-buff" type="number" name="attr_DEX_BUFF5" />
+						</td>
+					</tr>
+					<tr>
+						<td style="width: 5%;">CON:</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_CON_BUFF1_DESC" /><input class="sheet-buff" type="number" name="attr_CON_BUFF1" />
+						</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_CON_BUFF2_DESC" /><input class="sheet-buff" type="number" name="attr_CON_BUFF2" />
+						</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_CON_BUFF3_DESC" /><input class="sheet-buff" type="number" name="attr_CON_BUFF3" />
+						</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_CON_BUFF4_DESC" /><input class="sheet-buff" type="number" name="attr_CON_BUFF4" />
+						</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_CON_BUFF5_DESC" /><input class="sheet-buff" type="number" name="attr_CON_BUFF5" />
+						</td>
+					</tr>
+					<tr>
+						<td style="width: 5%;">INT:</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_INT_BUFF1_DESC" /><input class="sheet-buff" type="number" name="attr_INT_BUFF1" />
+						</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_INT_BUFF2_DESC" /><input class="sheet-buff" type="number" name="attr_INT_BUFF2" />
+						</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_INT_BUFF3_DESC" /><input class="sheet-buff" type="number" name="attr_INT_BUFF3" />
+						</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_INT_BUFF4_DESC" /><input class="sheet-buff" type="number" name="attr_INT_BUFF4" />
+						</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_INT_BUFF5_DESC" /><input class="sheet-buff" type="number" name="attr_INT_BUFF5" />
+						</td>
+					</tr>
+					<tr>
+						<td style="width: 5%;">PER:</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_PER_BUFF1_DESC" /><input class="sheet-buff" type="number" name="attr_PER_BUFF1" />
+						</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_PER_BUFF2_DESC" /><input class="sheet-buff" type="number" name="attr_PER_BUFF2" />
+						</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_PER_BUFF3_DESC" /><input class="sheet-buff" type="number" name="attr_PER_BUFF3" />
+						</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_PER_BUFF4_DESC" /><input class="sheet-buff" type="number" name="attr_PER_BUFF4" />
+						</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_PER_BUFF5_DESC" /><input class="sheet-buff" type="number" name="attr_PER_BUFF5" />
+						</td>
+					</tr>
+					<tr>
+						<td style="width: 5%;">CHA:</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_CHA_BUFF1_DESC" /><input class="sheet-buff" type="number" name="attr_CHA_BUFF1" />
+						</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_CHA_BUFF2_DESC" /><input class="sheet-buff" type="number" name="attr_CHA_BUFF2" />
+						</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_CHA_BUFF3_DESC" /><input class="sheet-buff" type="number" name="attr_CHA_BUFF3" />
+						</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_CHA_BUFF4_DESC" /><input class="sheet-buff" type="number" name="attr_CHA_BUFF4" />
+						</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_CHA_BUFF5_DESC" /><input class="sheet-buff" type="number" name="attr_CHA_BUFF5" />
+						</td>
+					</tr>
+					<tr>
+						<td style="width: 5%;">ATC:</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_ATKCAC_BUFF1_DESC" /><input class="sheet-buff" type="number" name="attr_ATKCAC_BUFF1" />
+						</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_ATKCAC_BUFF2_DESC" /><input class="sheet-buff" type="number" name="attr_ATKCAC_BUFF2" />
+						</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_ATKCAC_BUFF3_DESC" /><input class="sheet-buff" type="number" name="attr_ATKCAC_BUFF3" />
+						</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_ATKCAC_BUFF4_DESC" /><input class="sheet-buff" type="number" name="attr_ATKCAC_BUFF4" />
+						</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_ATKCAC_BUFF5_DESC" /><input class="sheet-buff" type="number" name="attr_ATKCAC_BUFF5" />
+						</td>
+					</tr>
+					<tr>
+						<td style="width: 5%;">ATD:</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_ATKTIR_BUFF1_DESC" /><input class="sheet-buff" type="number" name="attr_ATKTIR_BUFF1" />
+						</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_ATKTIR_BUFF2_DESC" /><input class="sheet-buff" type="number" name="attr_ATKTIR_BUFF2" />
+						</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_ATKTIR_BUFF3_DESC" /><input class="sheet-buff" type="number" name="attr_ATKTIR_BUFF3" />
+						</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_ATKTIR_BUFF4_DESC" /><input class="sheet-buff" type="number" name="attr_ATKTIR_BUFF4" />
+						</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_ATKTIR_BUFF5_DESC" /><input class="sheet-buff" type="number" name="attr_ATKTIR_BUFF5" />
+						</td>
+					</tr>
+					<tr>
+						<td style="width: 5%;">MAG:</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_ATKMAG_BUFF1_DESC" /><input class="sheet-buff" type="number" name="attr_ATKMAG_BUFF1" />
+						</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_ATKMAG_BUFF2_DESC" /><input class="sheet-buff" type="number" name="attr_ATKMAG_BUFF2" />
+						</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_ATKMAG_BUFF3_DESC" /><input class="sheet-buff" type="number" name="attr_ATKMAG_BUFF3" />
+						</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_ATKMAG_BUFF4_DESC" /><input class="sheet-buff" type="number" name="attr_ATKMAG_BUFF4" />
+						</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_ATKMAG_BUFF5_DESC" /><input class="sheet-buff" type="number" name="attr_ATKMAG_BUFF5" />
+						</td>
+					</tr>
+					<tr>
+						<td style="width: 5%;">MEN:</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_ATKMEN_BUFF1_DESC" /><input class="sheet-buff" type="number" name="attr_ATKMEN_BUFF1" />
+						</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_ATKMEN_BUFF2_DESC" /><input class="sheet-buff" type="number" name="attr_ATKMEN_BUFF2" />
+						</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_ATKMEN_BUFF3_DESC" /><input class="sheet-buff" type="number" name="attr_ATKMEN_BUFF3" />
+						</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_ATKMEN_BUFF4_DESC" /><input class="sheet-buff" type="number" name="attr_ATKMEN_BUFF4" />
+						</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_ATKMEN_BUFF5_DESC" /><input class="sheet-buff" type="number" name="attr_ATKMEN_BUFF5" />
+						</td>
+					</tr>
+					<tr>
+						<td style="width: 5%;">INIT:</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_INIT_BUFF1_DESC" /><input class="sheet-buff" type="number" name="attr_INIT_BUFF1" />
+						</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_INIT_BUFF2_DESC" /><input class="sheet-buff" type="number" name="attr_INIT_BUFF2" />
+						</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_INIT_BUFF3_DESC" /><input class="sheet-buff" type="number" name="attr_INIT_BUFF3" />
+						</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_INIT_BUFF4_DESC" /><input class="sheet-buff" type="number" name="attr_INIT_BUFF4" />
+						</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_INIT_BUFF5_DESC" /><input class="sheet-buff" type="number" name="attr_INIT_BUFF5" />
+						</td>
+					</tr>
+					<tr>
+						<td style="width: 5%;">DEF:</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_DEF_BUFF1_DESC" /><input class="sheet-buff" type="number" name="attr_DEF_BUFF1" />
+						</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_DEF_BUFF2_DESC" /><input class="sheet-buff" type="number" name="attr_DEF_BUFF2" />
+						</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_DEF_BUFF3_DESC" /><input class="sheet-buff" type="number" name="attr_DEF_BUFF3" />
+						</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_DEF_BUFF4_DESC" /><input class="sheet-buff" type="number" name="attr_DEF_BUFF4" />
+						</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_DEF_BUFF5_DESC" /><input class="sheet-buff" type="number" name="attr_DEF_BUFF5" />
+						</td>
+					</tr>
+				</table>
+				<div>
+					<input type="checkbox" class="sheet-block-switch" name="attr_voir_psy" title="@{voir_psy}" value="1"><span>Afficher les attributs PSY</span>
+					<div class="sheet-block-hidden"></div>
+					<div class="sheet-block-show">
+						<table>
+							<tr>
+								<td style="width: 5%;">PSYInf.:</td>
+								<td style="width: 19%;">
+									<input class="sheet-buff" style="width: 70%;" type="text" name="attr_PSYINFLU_BUFF1_DESC" /><input class="sheet-buff" type="number" name="attr_PSYINFLU_BUFF1" />
+								</td>
+								<td style="width: 19%;">
+									<input class="sheet-buff" style="width: 70%;" type="text" name="attr_PSYINFLU_BUFF2_DESC" /><input class="sheet-buff" type="number" name="attr_PSYINFLU_BUFF2" />
+								</td>
+								<td style="width: 19%;">
+									<input class="sheet-buff" style="width: 70%;" type="text" name="attr_PSYINFLU_BUFF3_DESC" /><input class="sheet-buff" type="number" name="attr_PSYINFLU_BUFF3" />
+								</td>
+								<td style="width: 19%;">
+									<input class="sheet-buff" style="width: 70%;" type="text" name="attr_PSYINFLU_BUFF4_DESC" /><input class="sheet-buff" type="number" name="attr_PSYINFLU_BUFF4" />
+								</td>
+								<td style="width: 19%;">
+									<input class="sheet-buff" style="width: 70%;" type="text" name="attr_PSYINFLU_BUFF5_DESC" /><input class="sheet-buff" type="number" name="attr_PSYINFLU_BUFF5" />
+								</td>
+							</tr>
+							<tr>
+								<td style="width: 5%;">PSYInt.:</td>
+								<td style="width: 19%;">
+									<input class="sheet-buff" style="width: 70%;" type="text" name="attr_PSYINTUI_BUFF1_DESC" /><input class="sheet-buff" type="number" name="attr_PSYINTUI_BUFF1" />
+								</td>
+								<td style="width: 19%;">
+									<input class="sheet-buff" style="width: 70%;" type="text" name="attr_PSYINTUI_BUFF2_DESC" /><input class="sheet-buff" type="number" name="attr_PSYINTUI_BUFF2" />
+								</td>
+								<td style="width: 19%;">
+									<input class="sheet-buff" style="width: 70%;" type="text" name="attr_PSYINTUI_BUFF3_DESC" /><input class="sheet-buff" type="number" name="attr_PSYINTUI_BUFF3" />
+								</td>
+								<td style="width: 19%;">
+									<input class="sheet-buff" style="width: 70%;" type="text" name="attr_PSYINTUI_BUFF4_DESC" /><input class="sheet-buff" type="number" name="attr_PSYINTUI_BUFF4" />
+								</td>
+								<td style="width: 19%;">
+									<input class="sheet-buff" style="width: 70%;" type="text" name="attr_PSYINTUI_BUFF5_DESC" /><input class="sheet-buff" type="number" name="attr_PSYINTUI_BUFF5" />
+								</td>
+							</tr>
+							<tr>
+								<td style="width: 5%;">DEFPsy:</td>
+								<td style="width: 19%;">
+									<input class="sheet-buff" style="width: 70%;" type="text" name="attr_DEP_BUFF1_DESC" /><input class="sheet-buff" type="number" name="attr_DEP_BUFF1" />
+								</td>
+								<td style="width: 19%;">
+									<input class="sheet-buff" style="width: 70%;" type="text" name="attr_DEP_BUFF2_DESC" /><input class="sheet-buff" type="number" name="attr_DEP_BUFF2" />
+								</td>
+								<td style="width: 19%;">
+									<input class="sheet-buff" style="width: 70%;" type="text" name="attr_DEP_BUFF3_DESC" /><input class="sheet-buff" type="number" name="attr_DEP_BUFF3" />
+								</td>
+								<td style="width: 19%;">
+									<input class="sheet-buff" style="width: 70%;" type="text" name="attr_DEP_BUFF4_DESC" /><input class="sheet-buff" type="number" name="attr_DEP_BUFF4" />
+								</td>
+								<td style="width: 19%;">
+									<input class="sheet-buff" style="width: 70%;" type="text" name="attr_DEP_BUFF5_DESC" /><input class="sheet-buff" type="number" name="attr_DEP_BUFF5" />
+								</td>
+							</tr>
+						</table>
+					</div>
+				</div>
+			</div> <!-- FIN BUFFS -->
+			<img class="sheet-imghr" src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/ChroniquesGalactiques/cog_hr.png" />
+		</div>
+	</div>
+	<div class="sheet-tab-content sheet-fp2">
+		<input type="radio" name="attr_tabvaiss" class="sheet-tab sheet-tab1" value="caracs" checked="checked"><span title="Caractéristiques"></span>
+		<input type="radio" name="attr_tabvaiss" class="sheet-tab sheet-tab2" value="config"><span title="Configuration"></span>
+		<img class="sheet-imghr-up" src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/ChroniquesGalactiques/cog_hr.png" />
+		<div class="sheet-tab-content sheet-tab1">
+			<div> <!-- Caracs + combat + PV + défense -->
+				<table>
+					<tr>
+						<td style="width:250px; vertical-align: top;"> <!-- Caracs + Chance -->
+							<table class="sheet-tabsep"> <!-- Caracs -->
+								<tr>
+									<td class="sheet-textfat">CARAC.</td>
+									<td></td>
+									<td class="sheet-textbase">Valeur</td>
+									<td class="sheet-textfat">Mod.</td>
+									<td class="sheet-textbase">Bonus</td>
+									<td class="sheet-textfat">Test</td>
+								</tr>
+								<tr>
+									<td class="sheet-boxtitre" colspan="2"><button class="sheet-boxtitre" type="roll" name="JET_FOR" title="Jet de Puissance" value="@(togm}&{template:co1} {{perso=@{character_name}}} {{name=Puissance}} {{subtags=Test}} {{carac=[[1d20cs20cf1[Dé] +[[@{FOR_TEST}]][Puissance] +@{POSTE_MOT} ]] }}"> FOR</button></td>
+									<td class="sheet-boxinput"><input type="number" name="attr_FORCE" title="@{FORCE}" value="10" min="0" /></td>
+									<td class="sheet-boxinputlight"><input type="number" name="attr_FOR" title="@{FOR}" value="floor((@{FORCE}-10)/2)" disabled /></td>
+									<td class="sheet-boxinputlight"><input type="number" name="attr_FOR_BONUS" title="@{FOR_BONUS} Bonus au Test" value="@{FOR_BUFF}" disabled /></td>
+									<td class="sheet-boxinputlight"><input type="number" name="attr_FOR_TEST" title="@{FOR_TEST}" value="@{FOR}+@{FOR_BONUS}" disabled /></td>
+								</tr>
+								<tr>
+									<td class="sheet-boxtitre" colspan="2"><button class="sheet-boxtitre" type="roll" name="JET_DEX" title="Jet de Manoeuvrabilit&eacute;" value="@(togm}&{template:co1} {{perso=@{character_name}}} {{name=Manoeuvrabilit&eacute;}} {{subtags=Test}} {{carac=[[1d20cs20cf1[Dé] +[[@{DEX_TEST}]][Manoeuvrabilit&eacute;] +@{POSTE_PIL} ]] }}"> DEX</button></td>
+									<td class="sheet-boxinput"><input type="number" name="attr_DEXTERITE" title="@{DEXTERITE}" value="10" min="0"  /></td>
+									<td class="sheet-boxinputlight"><input type="number" name="attr_DEX" title="@{DEX}" value="floor((@{DEXTERITE}-10)/2)" disabled /></td>
+									<td class="sheet-boxinputlight"><input type="number" name="attr_DEX_BONUS" title="@{DEX_BONUS} Bonus au Test" value="@{DEX_BUFF}" disabled /></td>
+									<td class="sheet-boxinputlight"><input type="number" name="attr_DEX_TEST" title="@{DEX_TEST}" value="@{DEX}+@{DEX_BONUS}" disabled /></td>
+								</tr>
+								<tr>
+									<td class="sheet-boxtitre" colspan="2"><button class="sheet-boxtitre" type="roll" name="JET_CON" title="Jet de Coque" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=Coque}} {{subtags=Test}} {{carac=[[1d20cs20cf1[Dé] + [[@{CON_TEST}]][Bonus] ]] }}"> CON</button></td>
+									<td class="sheet-boxinput"><input type="number" name="attr_CONSTITUTION" title="@{CONSTITUTION}" value="10" min="0"  /></td>
+									<td class="sheet-boxinputlight"><input type="number" name="attr_CON" title="@{CON}" value="floor((@{CONSTITUTION}-10)/2)" disabled /></td>
+									<td class="sheet-boxinputlight"><input type="number" name="attr_CON_BONUS" title="@{CON_BONS} Bonus au Test" value="@{CON_BUFF}" disabled /></td>
+									<td class="sheet-boxinputlight"><input type="number" name="attr_CON_TEST" title="@{CON_TEST}" value="@{CON}+@{CON_BONUS}" disabled /></td>
+								</tr>
+								<tr>
+									<td class="sheet-boxtitre" colspan="2"><button class="sheet-boxtitre" type="roll" name="JET_INT" title="Jet d'Ordinateurs de Vis&eacute;e" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=Ordinateur de Visée}} {{subtags=Test}} {{carac=[[1d20cs20cf1[Dé] +[[@{INT_TEST}]][Bonus] ]] }}"> INT</button></td>
+									<td class="sheet-boxinput"><input type="number" name="attr_INTELLIGENCE" title="@{INTELLIGENCE}" value="10" min="0"  /></td>
+									<td class="sheet-boxinputlight"><input type="number" name="attr_INT" title="@{INT}" value="floor((@{INTELLIGENCE}-10)/2)" disabled /></td>
+									<td class="sheet-boxinputlight"><input type="number" name="attr_INT_BONUS" title="@{INT_BONUS} Bonus au Test" value="@{INT_BUFF}" disabled /></td>
+									<td class="sheet-boxinputlight"><input type="number" name="attr_INT_TEST" title="@{INT_TEST}" value="@{INT}+@{INT_BONUS}" disabled /></td>
+								</tr>
+								<tr>
+									<td class="sheet-boxtitre" colspan="2"><button class="sheet-boxtitre" type="roll" name="JET_PER" title="Jet de Senseurs" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=Senseurs}} {{subtags=Test}} {{carac=[[1d20cs20cf1[Dé] +[[@{PER_TEST}]][Senseurs] +@{POSTE_SEN} ]] }}"> PER</button></td>
+									<td class="sheet-boxinput"><input type="number" name="attr_PERCEPTION" title="@{PERCEPTION}" value="10" min="0"  /></td>
+									<td class="sheet-boxinputlight"><input type="number" name="attr_PER" title="@{PER}" value="floor((@{PERCEPTION}-10)/2)" disabled /></td>
+									<td class="sheet-boxinputlight"><input type="number" name="attr_PER_BONUS" title="@{PER_BONUS} Bonus au Test" value="@{PER_BUFF}" disabled /></td>
+									<td class="sheet-boxinputlight"><input type="number" name="attr_PER_TEST" title="@{PER_TEST}" value="@{PER}+@{PER_BONUS}" disabled /></td>
+								</tr>
+								<tr>
+									<td class="sheet-boxtitre" colspan="2"><button class="sheet-boxtitre" type="roll" name="JET_CHA" title="Jet de Communications" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=Communications}} {{subtags=Test}} {{carac=[[1d20cs20cf1[Dé] + [[@{CHA_TEST}]][Comm.Systèmes] +@{POSTE_ORD} ]] }}"> CHA</button></td>
+									<td class="sheet-boxinput"><input type="number" name="attr_CHARISME" title="@{CHARISME}" value="10" min="0"  /></td>
+									<td class="sheet-boxinputlight"><input type="number" name="attr_CHA" title="@{CHA}" value="floor((@{CHARISME}-10)/2)" disabled /></td>
+									<td class="sheet-boxinputlight"><input type="number" name="attr_CHA_BONUS" title="@{CHA_BONUS} Bonus au Test" value="@{CHA_BUFF}" disabled /></td>
+									<td class="sheet-boxinputlight"><input type="number" name="attr_CHA_TEST" title="@{CHA_TEST}" value="@{CHA}+@{CHA_BONUS}" disabled /></td>
+								</tr>
+							</table> <!-- FIN Caracs -->
+							<table class="sheet-tabsep" style="margin-top: 20px;"> <!-- Energie -->
+								<tr>
+									<td class="sheet-boxtitre" title="Points d'énergie">PE</td>
+									<td class="sheet-boxinput"><input type="number" name="attr_PEV" value="0" title="@{PEV} Points d'énergie utilisés ou courants" /></td>
+									<td>/</td>
+									<td class="sheet-boxinputlight"><input type="number" name="attr_PEVBASE" title="@{PEVBASE} Points d'énergie de base" value="@{NIVEAU}" disabled /></td>
+									<td>+</td>
+									<td class="sheet-boxinputlight"><input type="number" name="attr_PEVDIV" title="@{PEVDIV} Points d'énergie additionnels" value="@{PEV_BUFF}" disabled/></td>
+									<td>+</td>
+									<td class="sheet-boxinputlight"><INPUT type="number" name="attr_PEVCAR" value="@{FOR}" title="@{PEVCAR} Mod. de puissance (FOR)" disabled /></td>
+									<td>=</td>
+									<td class="sheet-boxinputlight"><input type="number" name="attr_PEV_max" value="@{PEVBASE}+@{PEVDIV}+@{PEVCAR}" title="Points d'énergie maximums" disabled /></td>
+								</tr>
+							</table> <!-- FIN Energie -->
+						</td> <!-- FIN Caracs + Chance -->
+						<td  style="width:100%; vertical-align: top;"> <!-- Combat + PV + défense -->
+							<table>
+								<tr>
+									<td style="vertical-align: top;"> <!-- Combat -->
+										<table class="sheet-tabsep">
+											<tr>
+												<td class="sheet-textfat">COMBAT</td>
+												<td class="sheet-textbase">Base</td>
+												<td class="sheet-textbase">Mod.</td>
+												<td class="sheet-textbase">Div.</td>
+												<td class="sheet-textfat">Total</td>
+											</tr>
+											<tr>
+												<td class="sheet-boxtitre"><button class="sheet-boxtitre" type="roll" name="JET_TIRV" title="Jet d'attaque à distance" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=&Agrave; Distance}} {{subtags=Attaque}} {{attaque=[[1d20cs20cf1[Dé] + [[@{ATKTIRV}]][Bonus] ]] }}"> &Agrave; DISTANCE</button></td>
+												<td class="sheet-boxinputlight"><input type="number" name="attr_ATKTIRV_BASE" value="@{NIVEAU}" title="@{ATKTIRV_BASE} Score de base" disabled /></td>
+												<td class="sheet-boxinput">
+													<select class="sheet-carac" name="attr_ATKTIRV_CARAC" size="1" title="@{ATKTIRV_CARAC}">
+														<option value="@{INT}" selected>INT</option>
+													</select>
+												</td>
+												<td class="sheet-boxinputlight"><input type="number" name="attr_ATKTIRV_DIV" title="@{ATKTIRV_DIV} Bonus divers" value="@{ATKTIRV_BUFF}" disabled /></td>
+												<td class="sheet-boxinputlight"><input type="number" name="attr_ATKTIRV" title="@{ATKTIRV}" value="@{ATKTIRV_BASE}+@{ATKTIRV_CARAC}+@{ATKTIRV_DIV}" disabled /></td>
+											</tr>
+											<tr>
+												<td class="sheet-boxtitre" title="Poste de pilotage (PIL)">Pilotage</td>
+												<td class="sheet-boxinput" colspan="4"><input type="text" name="attr_POSTE_PIL" title="@{POSTE_PIL}" placeholder="[[@{Nom du pilote|DEX}]][DEX pilote] +Bonus/Rang[Pilotage]" /></td>
+											</tr>
+											<tr>
+												<td class="sheet-boxtitre" title="Salle des machines (MOT)">Machines</td>
+												<td class="sheet-boxinput" colspan="4"><input type="text" name="attr_POSTE_MOT" title="@{POSTE_MOT}" placeholder="[[@{Nom du mécanicien|INT}]][INT mécano] +Bonus/Rang[Moteurs]" /></td>
+											</tr>
+											<tr>
+												<td class="sheet-boxtitre" title="Console des senseurs (SEN)">Senseurs</td>
+												<td class="sheet-boxinput" colspan="4"><input type="text" name="attr_POSTE_SEN" title="@{POSTE_SEN}" placeholder="[[@{Nom du scantech|INT}]][INT scantech] +Bonus/Rang[Electronique]" /></td>
+											</tr>
+											<tr>
+												<td class="sheet-boxtitre" title="Console du système (ORD)">Ordinateurs</td>
+												<td class="sheet-boxinput" colspan="4"><input type="text" name="attr_POSTE_ORD" title="@{POSTE_ORD}" placeholder="[[@{Nom de l'infotech|INT}]][INT infotech] +Bonus/Rang[Electronique]" /></td>
+											</tr>
+											<tr>
+												<td class="sheet-boxtitre"><button class="sheet-boxtitre" type="roll" name="JET_INIT" title="Initiative" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=Initiative}} {{subtags=Combat}} {{carac=[[@{INITV}[Initiative] + @{INIT_VAR}[Dé(s)] &{tracker}]]}}"> INITIATIVE</button></td>
+												<td>&nbsp;</td>
+												<td class="sheet-boxinputlight"><input type="number" name="attr_INITV_CARAC" title="@{INITV_CARAC}" value="@{DEX}" disabled /></td>
+												<td class="sheet-boxinputlight"><input type="number" name="attr_INITV_PIL" title="@{INITV_PIL} Valeur de DEX du pilote" value="@{INIT_BUFF}" disabled /></td>
+												<td class="sheet-boxinputlight"><input type="number" name="attr_INITV" title="@{INITV}" value="@{INITV_CARAC}+@{INITV_PIL}" disabled /></td>
+											</tr>
+										</table>
+									</td> <!-- FIN Combat -->
+									<td style="vertical-align: top;"> <!-- PV -->
+										<table class="sheet-tabsep">
+											<tr>
+												<td class="sheet-textfat" colspan="2">STRUCTURE</td>
+											</tr>
+											<tr>
+												<td class="sheet-boxtitre">DV</button></td>
+												<td class="sheet-boxinput">
+													<select class="sheet-carac" name="attr_DV" size="1" title="@{DV} D&eacute; de Structure">
+														<option value="0" selected >-</option>
+														<option value="4">d4</option>
+														<option value="6">d6</option>
+														<option value="8">d8</option>
+														<option value="10">d10</option>
+														<option value="12">d12</option>
+													</select>
+												</td>
+											</tr>
+											<tr>
+												<td class="sheet-boxtitre">PV</button></td>
+												<td class="sheet-boxinput"><input type="number" name="attr_PV_max" title="@{PV|max} Points de Structure maximum"  value="0" /></td>
+											</tr>
+											<tr>
+												<td  class="sheet-boxinput" COLSPAN="2">
+													<span class="textbase">PV restants</span>&nbsp;
+													<input type="number" name="attr_PV" title="@{PV} Points de Structure restants" value="0" />
+												</td>
+											</tr>
+											<tr>
+												<td  class="sheet-boxinput" COLSPAN="2">
+													<span class="textbase">DM temp.</span>&nbsp;
+													<input type="number" name="attr_DMTEMP" title="@{DMTEMP} Dommages EMP"  value="0" />
+												</td>
+											</tr>
+											<tr>
+												<td class="sheet-boxtitre" title="Boucliers (réduction des dommages)">RD</td>
+												<td class="sheet-boxinput"><input type="number" name="attr_RD" title="@{RD} Réduction des dommages" value="0" /></td>
+											</tr>
+											<tr><td>&nbsp;</td></tr>
+										</table>
+									</td> <!-- FIN PV -->
+								</tr>
+								<tr>
+									<td colspan="2"  style="vertical-align: top;"> <!-- Défense -->
+										<table class="sheet-tabsep">
+											<tr>
+												<td class="sheet-textfat">D&Eacute;FENSES</td>
+												<td>&nbsp;</td>
+												<td class="sheet-textbase">Mod. DEX/CON</td>
+												<td class="sheet-textbase">Pilote</td>
+												<td class="sheet-textbase">Mod. PER</td>
+												<td class="sheet-textbase">Scantech</td>
+												<td class="sheet-textfat">Total</td>
+											</tr>
+											<tr>
+												<td class="sheet-boxtitre">DEF (rapidité)</td>
+												<td class="sheet-boxinputlight">10+</td>
+												<td class="sheet-boxinputlight"><input type="number" name="attr_DEFVDEX" value="@{DEX}" title="@{DEFVDEX} Bonus de Manoeuvrabilit&eacute;" disabled /></td>
+												<td class="sheet-boxinputlight"><input type="number" name="attr_DEFVPIL" value="@{DEFVPIL_BUFF}" title="@{DEFVPIL} Bonus du Pilote" disabled /></td>
+												<td class="sheet-boxinputlight"><input type="number" name="attr_DEFVPER" value="@{PER}" title="@{DEFVPER} Bonus de Senseurs" disabled /></td>
+												<td class="sheet-boxinputlight"><input type="number" name="attr_DEFVSEN" value="@{DEFVSEN_BUFF}" title="@{DEFVSEN} Bonus du Scantech" disabled /></td>
+												<td class="sheet-boxinputlight"><input type="number" name="attr_DEFRAP" value="10+@{DEFVDEX}+@{DEFVPIL}+@{DEFVPER}+@{DEFVSEN}" title="@{DEFRAP} D&eacute;fense (rapidit&eacute;)" disabled /></td>
+											</tr>
+											<tr>
+												<td class="sheet-boxtitre">DEF (solidité)</td>
+												<td class="sheet-boxinputlight">10+</td>
+												<td class="sheet-boxinputlight"><input type="number" name="attr_DEFVCON" value="@{CON}" title="@{DEFVCON} Bonus de Coque" disabled /></td>
+												<td class="sheet-textbase">&nbsp;</td>
+												<td class="sheet-textbase">&nbsp;</td>
+												<td class="sheet-textbase">&nbsp;</td>
+												<td class="sheet-boxinputlight"><input type="number" name="attr_DEFSOL" value="10+@{DEFVCON}+@{DEFVPER}+@{DEFVSEN}" title="@{DEFSOL} D&eacute;fense (solidit&eacute;)" disabled /></td>
+											</tr>
+										</table>
+									</td>
+								</tr>
+							</table>
+						</td> <!-- FIN Combat + PV + défense -->
+					</tr>
+				</table>
+			</div> <!-- FIN Caracs + combat + PV + défense  -->
+			<img class="sheet-imghr" src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/ChroniquesGalactiques/cog_hr.png" />
+			<div> <!-- Armes -->
+				<table class="sheet-tabsep" title="repeating_armesv">
+					<tr>
+						<td class="sheet-textfatleft" style="width:155px;">ARMES / ATTAQUES</td>
+						<td class="sheet-textbase" style="width:140px;">ATTAQUE</td>
+						<td class="sheet-textbase" style="width:20px;">CRIT.</td>
+						<td class="sheet-textbase" style="width:185px;">DM</td>
+						<td class="sheet-textbase" style="widht:100%;">SPÉCIAL</td>
+					</tr>
+				</table>
+				<fieldset class="repeating_armesv">
+					<div class="attack">
+						<input class="options-flag" name="attr_armeoptflag" type="checkbox" title="Montrer/cacher les options"><span>y</span>
+						<div>
+							<table class="sheet-tabsep">
+								<tr>
+									<td>
+										<button type="roll" class="sheet-neutre" name="attr_jet" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=@{armenom}}} {{subtags=Attaque}} {{desc=@{armejetn}}} {{attaque=[[@{armejetd}cs>@{armecrit}cf<@{armeinct}[Dé] + [[@{armeatk}]][Attaque] + @{armecan} + @{armeatkdiv}[Bonus] ]]}} {{degats=[[@{armedmnbde}d@{armedmde}[Dé DM] + [[@{armedmcar}]][Mod.DM] + @{armedmdiv}[Bonus DM] ]]}} {{special=@{armespec}}}" />
+									</td>
+									<td class="sheet-boxinputleft" style="min-width: 130px;">
+										<input type="text" name="attr_armenom" title="@{armenom}" style="font-weight: bold;" placeholder="Arme/attaque"/>
+									</td>
+									<td class="sheet-boxinputleft" style="min-width: 145px;">
+											<select class="sheet-carac" style="width: 87px;" name="attr_armeatk" title="@{armeatk}" size="1">
+												<option value="@{ATKTIRV}" selected>DISTANCE</option>
+											</select>+<input type="number" style="width:32px;" name="attr_armeatkdiv" value="0" title="@{armeatkdiv} Bonus d'attaque divers" />
+									</td>
+									<td class="sheet-boxinputleft" style="text-align: right;">
+										<input type="number" name="attr_armecrit" style="width:32px;" min="2" max="20" value="20" title="@{armecrit} Seuil de Critique (par défaut 20)" />
+									</td>
+									<td class="sheet-boxinputleft">
+										<input type="number" style="width:32px;" name="attr_armedmnbde" value="1" title="@{armedmnbde} Nombre de dés de dommage" />
+										<select class="sheet-carac"  style="width:47px;" name="attr_armedmde" size="1" title="@{armedmde} Dé de dommage">
+											<option value="4">d4</option>
+											<option value="6" selected>d6</option>
+											<option value="8">d8</option>
+											<option value="10">d10</option>
+											<option value="12">d12</option>
+										</select>+<select class="sheet-carac" style="width:52px;" name="attr_armedmcar" size="1" title="@{armedmcar} Modificateur aux dommages">
+											<option value="0">-</option>
+											<optgroup label="Mod. de base">
+												<option value="@{FOR}">FOR</option>
+												<option value="@{DEX}">DEX</option>
+												<option value="@{CON}">CON</option>
+												<option value="@{INT}">INT</option>
+												<option value="@{PER}">PER</option>
+												<option value="@{CHA}">CHA</option>
+											</optgroup>
+											<optgroup label="Mod. de test">
+												<option value="@{FOR_TEST}" selected>FOR</option>
+												<option value="@{DEX_TEST}">DEX</option>
+												<option value="@{CON_TEST}">CON</option>
+												<option value="@{INT_TEST}">INT</option>
+												<option value="@{PER_TEST}">PER</option>
+												<option value="@{CHA_TEST}">CHA</option>
+											</optgroup>
+										</select>+<input type="number" style="width:32px;" name="attr_armedmdiv" value="0" title="@{armedmdiv} Bonus de dommage divers" />
+									</td>
+									<td class="sheet-boxinputleft" style="width:100%;">
+										<textarea name="attr_armespec" title="@{armespec}" placeholder="Notes, capacités spéciales, effet ..." title="@{armespec} Notes, capacités spéciales, effet ..."></textarea>
+									</td>
+								</tr>
+							</table>
+						</div>
+						<div class="options">
+							<table class="sheet-tabsep">
+								<tr>
+									<td style="width: 18px;">&nbsp;</td>
+									<td class="sheet-boxinputleft" style="width: 130px;">
+										<input type="text" name="attr_armejetn" style="font-weight: bold;" placeholder="Nom de l'attaque" title="@{armejetn}" />
+									</td>
+									<td class="sheet-boxinputleft" style="width: 145px;">&nbsp;Type de jet
+										<select class="sheet-carac" style="width: 65px;" name="attr_armejetd" size="1" title="@{armejetd} Jet d'attaque : 'Risque' = avec d12, 'Expert' = meilleur de deux d20">
+											<option value="1d20" selected>Normal</option>
+											<option value="1d12">Risque (d12)</option>
+											<option value="2d20kh1">Expert (2 d20)</option>
+										</select>
+									</td>
+									<td class="sheet-boxinputleft" style="width: 32px;">
+										<input type="number" style="width: 32px;" name="attr_armeinct" min="1" max="19" value="1" title="@{armeinct} Seuil d'incident de tir (par défaut 1)" />
+									</td>
+									<td class="sheet-boxinputleft">
+										<input type="text" name="attr_armecan" placeholder="[[@{Nom du canonnier|DEX}]][DEX canonnier] +Bonus/Rang[Armes lourdes]" title="@{armecan} Canonnier (CAN)" />
+									</td>
+								</tr>
+							</table>
+						</div>
+					</div>
+				</fieldset>
+			</div>
+			<img class="sheet-imghr" src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/ChroniquesGalactiques/cog_hr.png" />
+		</div>
+		<div class="sheet-tab-content sheet-tab2">
+			<div class="sheet-row"> <!-- Config -->
+				<table class="sheet-tabsep">
+					<tr>
+						<td style="width: 15%;">
+							<span class="textbase">Jets</span>&nbsp;
+							<select class="sheet-carac" style="width: 75px;" name="attr_togm" title="@{togm}" size="1">
+								<option value="" selected>Normaux</option>
+								<option value="/w gm ">Cachés</option>
+							</select>
+						</td>
+						<td style="width: 20%;">
+							<span class="textbase">Initiative variable</span>&nbsp;<input type="checkbox" name="attr_INIT_VAR" title="@{INIT_VAR}" value="[[1d6!]]" />
+						</td>
+						<td style="width: 25%;"></td>
+						<td style="width: 20%;"></td>
+						<td style="width: 20%;"></td>
+					</tr>
+				</table>
+			</div> <!-- FIN Config -->
+			<img class="sheet-imghr" src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/ChroniquesGalactiques/cog_hr.png" />
+			<div class="sheet-row"> <!-- BUFFS -->
+				<div class="sheet-textfatleft">BUFFS</div>
+				<table class="sheet-tabsep">
+					<tr>
+						<td style="width: 5%;">FOR:</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_FOR_BUFF1_DESC" /><input class="sheet-buff" type="number" name="attr_FOR_BUFF1" />
+						</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_FOR_BUFF2_DESC" /><input class="sheet-buff" type="number" name="attr_FOR_BUFF2" />
+						</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_FOR_BUFF3_DESC" /><input class="sheet-buff" type="number" name="attr_FOR_BUFF3" />
+						</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_FOR_BUFF4_DESC" /><input class="sheet-buff" type="number" name="attr_FOR_BUFF4" />
+						</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_FOR_BUFF5_DESC" /><input class="sheet-buff" type="number" name="attr_FOR_BUFF5" />
+						</td>
+					</tr>
+					<tr>
+						<td style="width: 5%;">DEX:</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_DEX_BUFF1_DESC" /><input class="sheet-buff" type="number" name="attr_DEX_BUFF1" />
+						</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_DEX_BUFF2_DESC" /><input class="sheet-buff" type="number" name="attr_DEX_BUFF2" />
+						</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_DEX_BUFF3_DESC" /><input class="sheet-buff" type="number" name="attr_DEX_BUFF3" />
+						</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_DEX_BUFF4_DESC" /><input class="sheet-buff" type="number" name="attr_DEX_BUFF4" />
+						</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_DEX_BUFF5_DESC" /><input class="sheet-buff" type="number" name="attr_DEX_BUFF5" />
+						</td>
+					</tr>
+					<tr>
+						<td style="width: 5%;">CON:</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_CON_BUFF1_DESC" /><input class="sheet-buff" type="number" name="attr_CON_BUFF1" />
+						</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_CON_BUFF2_DESC" /><input class="sheet-buff" type="number" name="attr_CON_BUFF2" />
+						</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_CON_BUFF3_DESC" /><input class="sheet-buff" type="number" name="attr_CON_BUFF3" />
+						</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_CON_BUFF4_DESC" /><input class="sheet-buff" type="number" name="attr_CON_BUFF4" />
+						</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_CON_BUFF5_DESC" /><input class="sheet-buff" type="number" name="attr_CON_BUFF5" />
+						</td>
+					</tr>
+					<tr>
+						<td style="width: 5%;">INT:</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_INT_BUFF1_DESC" /><input class="sheet-buff" type="number" name="attr_INT_BUFF1" />
+						</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_INT_BUFF2_DESC" /><input class="sheet-buff" type="number" name="attr_INT_BUFF2" />
+						</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_INT_BUFF3_DESC" /><input class="sheet-buff" type="number" name="attr_INT_BUFF3" />
+						</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_INT_BUFF4_DESC" /><input class="sheet-buff" type="number" name="attr_INT_BUFF4" />
+						</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_INT_BUFF5_DESC" /><input class="sheet-buff" type="number" name="attr_INT_BUFF5" />
+						</td>
+					</tr>
+					<tr>
+						<td style="width: 5%;">PER:</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_PER_BUFF1_DESC" /><input class="sheet-buff" type="number" name="attr_PER_BUFF1" />
+						</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_PER_BUFF2_DESC" /><input class="sheet-buff" type="number" name="attr_PER_BUFF2" />
+						</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_PER_BUFF3_DESC" /><input class="sheet-buff" type="number" name="attr_PER_BUFF3" />
+						</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_PER_BUFF4_DESC" /><input class="sheet-buff" type="number" name="attr_PER_BUFF4" />
+						</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_PER_BUFF5_DESC" /><input class="sheet-buff" type="number" name="attr_PER_BUFF5" />
+						</td>
+					</tr>
+					<tr>
+						<td style="width: 5%;">CHA:</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_CHA_BUFF1_DESC" /><input class="sheet-buff" type="number" name="attr_CHA_BUFF1" />
+						</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_CHA_BUFF2_DESC" /><input class="sheet-buff" type="number" name="attr_CHA_BUFF2" />
+						</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_CHA_BUFF3_DESC" /><input class="sheet-buff" type="number" name="attr_CHA_BUFF3" />
+						</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_CHA_BUFF4_DESC" /><input class="sheet-buff" type="number" name="attr_CHA_BUFF4" />
+						</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_CHA_BUFF5_DESC" /><input class="sheet-buff" type="number" name="attr_CHA_BUFF5" />
+						</td>
+					</tr>
+					<tr>
+						<td style="width: 5%;">ATD:</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_ATKTIRV_BUFF1_DESC" /><input class="sheet-buff" type="number" name="attr_ATKTIRV_BUFF1" />
+						</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_ATKTIRV_BUFF2_DESC" /><input class="sheet-buff" type="number" name="attr_ATKTIRV_BUFF2" />
+						</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_ATKTIRV_BUFF3_DESC" /><input class="sheet-buff" type="number" name="attr_ATKTIRV_BUFF3" />
+						</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_ATKTIRV_BUFF4_DESC" /><input class="sheet-buff" type="number" name="attr_ATKTIRV_BUFF4" />
+						</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_ATKTIRV_BUFF5_DESC" /><input class="sheet-buff" type="number" name="attr_ATKTIRV_BUFF5" />
+						</td>
+					</tr>
+					<tr>
+						<td style="width: 5%;">INIT:</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_INIT_BUFF1_DESC" /><input class="sheet-buff" type="number" name="attr_INIT_BUFF1" />
+						</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_INIT_BUFF2_DESC" /><input class="sheet-buff" type="number" name="attr_INIT_BUFF2" />
+						</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_INIT_BUFF3_DESC" /><input class="sheet-buff" type="number" name="attr_INIT_BUFF3" />
+						</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_INIT_BUFF4_DESC" /><input class="sheet-buff" type="number" name="attr_INIT_BUFF4" />
+						</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_INIT_BUFF5_DESC" /><input class="sheet-buff" type="number" name="attr_INIT_BUFF5" />
+						</td>
+					</tr>
+					<tr>
+						<td style="width: 5%;">PIL:</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_DEFVPIL_BUFF1_DESC" /><input class="sheet-buff" type="number" name="attr_DEFVPIL_BUFF1" />
+						</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_DEFVPIL_BUFF2_DESC" /><input class="sheet-buff" type="number" name="attr_DEFVPIL_BUFF2" />
+						</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_DEFVPIL_BUFF3_DESC" /><input class="sheet-buff" type="number" name="attr_DEFVPIL_BUFF3" />
+						</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_DEFVPIL_BUFF4_DESC" /><input class="sheet-buff" type="number" name="attr_DEFVPIL_BUFF4" />
+						</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_DEFVPIL_BUFF5_DESC" /><input class="sheet-buff" type="number" name="attr_DEFVPIL_BUFF5" />
+						</td>
+					</tr>
+					<tr>
+						<td style="width: 5%;">SEN:</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_DEFVSEN_BUFF1_DESC" /><input class="sheet-buff" type="number" name="attr_DEFVSEN_BUFF1" />
+						</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_DEFVSEN_BUFF2_DESC" /><input class="sheet-buff" type="number" name="attr_DEFVSEN_BUFF2" />
+						</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_DEFVSEN_BUFF3_DESC" /><input class="sheet-buff" type="number" name="attr_DEFVSEN_BUFF3" />
+						</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_DEFVSEN_BUFF4_DESC" /><input class="sheet-buff" type="number" name="attr_DEFVSEN_BUFF4" />
+						</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_DEFVSEN_BUFF5_DESC" /><input class="sheet-buff" type="number" name="attr_DEFVSEN_BUFF5" />
+						</td>
+					</tr>
+					<tr>
+						<td style="width: 5%;">PE:</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_PEV_BUFF1_DESC" /><input class="sheet-buff" type="number" name="attr_PEV_BUFF1" />
+						</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_PEV_BUFF2_DESC" /><input class="sheet-buff" type="number" name="attr_PEV_BUFF2" />
+						</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_PEV_BUFF3_DESC" /><input class="sheet-buff" type="number" name="attr_PEV_BUFF3" />
+						</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_PEV_BUFF4_DESC" /><input class="sheet-buff" type="number" name="attr_PEV_BUFF4" />
+						</td>
+						<td style="width: 19%;">
+							<input class="sheet-buff" style="width: 70%;" type="text" name="attr_PEV_BUFF5_DESC" /><input class="sheet-buff" type="number" name="attr_PEV_BUFF5" />
+						</td>
+					</tr>
+				</table>
+			</div>
+		</div>
+	</div>
+	<div class="sheet-tab-content sheet-fp3">
+		<input type="radio" name="attr_tab_pnj" class="sheet-tab sheet-tab1" value="caracs" checked="checked"><span title="Caractéristiques"></span>
+		<input type="radio" name="attr_tab_pnj" class="sheet-tab sheet-tab2" value="config"><span title="Configuration"></span>
+		<img class="sheet-imghr-up" src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/ChroniquesGalactiques/cog_hr.png" />
+		<div class="sheet-tab-content sheet-tab1">
+		    <diV>
+		        <div class="sheet-2colrow">
+		            <div class="sheet-col">
+		                <div class="sheet-row">
+		                    <span class="textfatleft">Attributs</span>
+		                </div>
+    		            <div class="sheet-3colrow">
+        		            <div class="sheet-col" style="width: 25%;">
+        						<div class="sheet-boxtitre"><button class="sheet-boxtitre" type="roll" name="jet_pnj_for" title="Jet de Force" value="@(pnj_togm}&{template:co1} {{perso=@{character_name}}} {{name=Force}} {{subtags=Test}} {{carac=[[@{pnj_jetfor}cs20cf1[Dé] + [[@{pnj_for}]][FOR] ]] }}"> FOR</div>
+        						<div class="sheet-boxinput">
+        						    <input class="sheet-carac" name="attr_pnj_for" type="number" title="@{pnj_for}" />
+									<select class="sheet-selectmin" name="attr_pnj_jetfor" title="@{pnj_jetfor}">
+										<option value="1d20" selected>N Normale</option>
+										<option value="2d20kh1">S Supérieure</option>
+									</select>
+        						</div>
+        		            </div>
+        		            <div class="sheet-col" style="width: 25%;">
+        						<div class="sheet-boxtitre"><button class="sheet-boxtitre" type="roll" name="jet_pnj_dex" title="Jet de Dextérité" value="@(pnj_togm}&{template:co1} {{perso=@{character_name}}} {{name=Dextérité}} {{subtags=Test}} {{carac=[[@{pnj_jetdex}cs20cf1[Dé] + [[@{pnj_dex}]][DEX] ]] }}"> DEX</div>
+        						<div class="sheet-boxinput">
+        						    <input class="sheet-carac" name="attr_pnj_dex" type="number" title="@{pnj_dex}" />
+									<select class="sheet-selectmin" name="attr_pnj_jetdex" title="@{pnj_jetdex}">
+										<option value="1d20" selected>N Normale</option>
+										<option value="2d20kh1">S Supérieure</option>
+									</select>
+        						</div>
+        		            </div>
+        		            <div class="sheet-col" style="width: 25%;">
+        						<div class="sheet-boxtitre"><button class="sheet-boxtitre" type="roll" name="jet_pnj_con" title="Jet de Constitution" value="@(pnj_togm}&{template:co1} {{perso=@{character_name}}} {{name=Constitution}} {{subtags=Test}} {{carac=[[@{pnj_jetcon}cs20cf1[Dé] + [[@{pnj_con}]][CON] ]] }}"> CON</div>
+        						<div class="sheet-boxinput">
+        						    <input class="sheet-carac" name="attr_pnj_con" type="number" title="@{pnj_con}" />
+									<select class="sheet-selectmin" name="attr_pnj_jetcon" title="@{pnj_jetcon}">
+										<option value="1d20" selected>N Normale</option>
+										<option value="2d20kh1">S Supérieure</option>
+									</select>
+        						</div>
+        		            </div>
+    		            </div>
+    		            <div class="sheet-row">&nbsp;</div>
+    		            <div class="sheet-3colrow">
+        		            <div class="sheet-col" style="width: 25%;">
+        						<div class="sheet-boxtitre"><button class="sheet-boxtitre" type="roll" name="jet_pnj_int" title="Jet d'Intelligence" value="@(pnj_togm}&{template:co1} {{perso=@{character_name}}} {{name=Intelligence}} {{subtags=Test}} {{carac=[[@{pnj_jetint}cs20cf1[Dé] + [[@{pnj_int}]][INT] ]] }}"> INT</div>
+        						<div class="sheet-boxinput">
+        						    <input class="sheet-carac" name="attr_pnj_int" type="number" title="@{pnj_int}" />
+									<select class="sheet-selectmin" name="attr_pnj_jetint" title="@{pnj_jetint}">
+										<option value="1d20" selected>N Normale</option>
+										<option value="2d20kh1">S Supérieure</option>
+									</select>
+        						</div>
+        		            </div>
+        		            <div class="sheet-col" style="width: 25%;">
+        						<div class="sheet-boxtitre"><button class="sheet-boxtitre" type="roll" name="jet_pnj_per" title="Jet de Perception" value="@(pnj_togm}&{template:co1} {{perso=@{character_name}}} {{name=Perception}} {{subtags=Test}} {{carac=[[@{pnj_jetper}cs20cf1[Dé] + [[@{pnj_per}]][PER] ]] }}"> PER</div>
+        						<div class="sheet-boxinput">
+        						    <input class="sheet-carac" name="attr_pnj_per" type="number" title="@{pnj_per}" />
+									<select class="sheet-selectmin" name="attr_pnj_jetper" title="@{pnj_jetper}">
+										<option value="1d20" selected>N Normale</option>
+										<option value="2d20kh1">S Supérieure</option>
+									</select>
+        						</div>
+        		            </div>
+        		            <div class="sheet-col" style="width: 25%;">
+        						<div class="sheet-boxtitre"><button class="sheet-boxtitre" type="roll" name="jet_pnj_cha" title="Jet de Charisme" value="@(pnj_togm}&{template:co1} {{perso=@{character_name}}} {{name=Charisme}} {{subtags=Test}} {{carac=[[@{pnj_jetcha}cs20cf1[Dé] + [[@{pnj_cha}]][CHA] ]] }}"> CHA</div>
+        						<div class="sheet-boxinput">
+        						    <input class="sheet-carac" name="attr_pnj_cha" type="number" title="@{pnj_cha}" />
+									<select class="sheet-selectmin" name="attr_pnj_jetcha" title="@{pnj_jetcha}">
+										<option value="1d20" selected>N Normale</option>
+										<option value="2d20kh1">S Supérieure</option>
+									</select>
+        						</div>
+        		            </div>
+    		            </div>
+    		            <div class="sheet-row">&nbsp;</div>
+    		            <div class="sheet-3colrow">
+    		                <div class="sheet-col" style="width: 25%;">
+        						<div class="sheet-boxtitre"><button class="sheet-boxtitre" type="roll" name="jet_pnj_init" title="Jet d'Initiative" value="@(pnj_togm}&{template:co1} {{perso=@{character_name}}} {{name=Initiative}} {{subtags=Combat}} {{carac=[[@{pnj_init}[Init.] + @{pnj_init_var}[Dé(s)] &{tracker}]]}}"> Init.</div>
+        						<div class="sheet-boxinput">
+        						    <input class="sheet-carac" name="attr_pnj_init" type="number" title="@{pnj_init}" />
+        						</div>
+    		                </div>
+    		                <div class="sheet-col" style="width: 25%;">
+    		                    <div class="sheet-boxtitre">DEF</div>
+    		                    <div class="sheet-boxinput">
+    		                        <input class="sheet-carac" name="attr_pnj_def" type="number" title="@{pnj_def}" />
+    		                    </div>
+    		                </div>
+    		                <div class="sheet-col" style="width: 25%;">
+    		                    <div class="sheet-boxtitre">PV</div>
+    		                    <div class="sheet-boxinput">
+    		                        <input class="sheet-carac" name="attr_pnj_pv" type="number" title="@{pnj_pv} PV courants" /> / <input class="sheet-carac" name="attr_pnj_pv_max" type="number" title="@{pnj_pv|max} PV MAX" />
+    		                    </div>
+    		                </div>
+    		            </div>
+    		            <div class="sheet-row">
+		                    <span class="textfatleft" title="repeating_pnjatk">Attaques</span>
+    		            </div>
+    		            <div class="sheet-row">
+            				<fieldset class="repeating_pnjatk">
+    							<table class="sheet-tabsep">
+    								<tr>
+    								    <td>
+    								        <button type="roll" class="sheet-neutre" style="width: 25px;" name="attr_jet" value="@{pnj_togm}&{template:co1} {{perso=@{character_name}}} {{name=@{atknom}}} {{subtags=Attaque}} {{attaque=[[@{atkjet}[Dé] + [[@{atkbonus}]][Attaque] ]]}} {{degats=[[@{atkdmnbde}d@{atkdmde}[Dé DM] + [[@{atkdmbonus}]][Mod.DM] ]]}} {{special=@{atkspec}}}" />
+    								    </td>
+    								    <td class="sheet-boxinputleft" style="min-width: 200px;">
+    								        <input type="text" class="sheet-carac" style="width: 150px;" name="attr_atknom" title="@{atknom} Nom de l'arme / attaque" />
+        									<select class="sheet-selectmin" name="attr_atkjet" title="@{atkjet} Jet d'attaque normal (d20) ou expert (meilleur de de">
+        										<option value="1d20" selected>N Normal</option>
+        										<option value="2d20kh1">E Expert</option>
+        									</select>
+    								        <input type="number" class="sheet-carac" name="attr_atkbonus" title="@{atkbonus} Bonus d'attaque" />
+    								    </td>
+    								    <td class="sheet-boxinput">
+    								        <input type="number" name="attr_atkdmnbde" title="@{atkdmnbde} Nombre de dés de DM" />
+    								        <select class="sheet-carac" style="width: 40px;" name="attr_atkdmde" title="@{atkdmde} Dé de DM">
+    								            <optgroup label="Normaux">
+    								                <option value="3">d3</option>
+    								                <option value="4">d4</option>
+    								                <option value="6">d6</option>
+    								                <option value="8">d8</option>
+    								                <option value="10">d10</option>
+    								                <option value="12">d12</option>
+    								            </optgroup>
+    								            <optgroup label="Sans limite">
+    								                <option value="3!">d3</option>
+    								                <option value="4!">d4</option>
+    								                <option value="6!" selected>d6</option>
+    								                <option value="8!">d8</option>
+    								                <option value="10!">d10</option>
+    								                <option value="12!">d12</option>
+    								            </optgroup>
+    								        </select>
+    								        + <input type="number" name="attr_atkdmbonus" title="@{atkdmbonus} Bonus aux DM" />
+    								    </td>
+    								</tr>
+    								<tr>
+    								    <td class="sheet-boxinput" colspan="3">
+    								        <textarea class="sheet-carac" name="attr_atkspec" title="@{atkspec} Autres effets"></textarea>
+    								    </td>
+    								</tr>
+    							</table>
+    		                </fieldset>
+    		            </div>
                     </div>
-                    <div class="options">
-                        <table class="sheet-tabsep">
-                            <tr>
-                                <td style="width: 18px;">&nbsp;</td>
-                                <td class="sheet-boxinputleft" style="width: 130px;">
-                                    <input type="text" name="attr_armejetn" style="font-weight: bold;" placeholder="Nom de l'attaque" title="@{armejetn}" />
-                                </td>
-                                <td class="sheet-boxinputleft" style="width: 150px;">&nbsp;Type de jet
-                                    <select class="sheet-carac" style="width: 65px;" name="attr_armejetd" size="1" title="@{armejetd} Jet d'attaque : 'Risque' = avec d12, 'Expert' = meilleur de deux d20">
-                                        <option value="@{JETNORMAL}" selected>Normal</option>
-                                        <option value="@{JETRISQUE}">Risque (d12)</option>
-                                        <option value="@{JETSUP}">Expert (2 d20)</option>
-                                    </select>
-                                </td>
-                                <td class="sheet-boxinputleft" style="width: 32px;">
-                                    <input type="number" style="width: 32px;" name="attr_armeinct" min="1" max="19" value="1" title="@{armeinct} Seuil d'incident de tir (par défaut 1)" />
-                                </td>
-        						<td class="sheet-boxinputleft" style="width: 188px;">
-        						    <select class="sheet-carac" style="width: 110px;" name="attr_armedmrel" size="1" title="@{armedmrel} Relance dés de DM = (r)eroll -- 1 fois = (r)eroll (o)nce">
-        						        <option value="" selected>-</option>
-        						        <option value="r">Relance DM</option>
-        						        <option value="ro">Relance DM (1 fois)</option>
-        						    </select>
-        						    <input type="text" style="width: 70px;" name="attr_armedmvrel" title="@{armedmvrel} Seuil de relance (relance les 1 si non indiqué)" />
-        						</td>
-                                <td>&nbsp;</td>
-                                <td>&nbsp;</td>
-                            </tr>
-                        </table>
+		            <div class="sheet-col">
+		                <div class="sheet-row">
+		                    <span class="textfatleft">Capacités</span>
+		                </div>
+		                <div class="sheet-row">
+		                    <textarea name="attr_pnj_divers" style="height: 15em;"></textarea>
+		                </div>
+		            </div>
+		        </div>
+		    </diV>
+		</div>
+		<div class="sheet-tab-content sheet-tab2">
+		    <div class="sheet-3colrow">
+		        <div class="sheet-col">
+					<span class="textbase">Jets</span>&nbsp;
+					<select class="sheet-carac" style="width: 75px;" name="attr_pnj_togm" title="@{pnj_togm}" size="1">
+						<option value="" selected>Normaux</option>
+						<option value="/w gm ">Cachés</option>
+					</select>
+		        </div>
+		        <div class="sheet-col">
+		            <span class="textbase">Initiative variable</span>&nbsp;<input type="checkbox" name="attr_pnj_init_var" title="@{pnj_init_var}" value="[[1d6!]]" />
+		        </div>
+		    </div>
+		    <div class="sheet-col" style="width: 50%;">
+		        <div class="sheet-row">
+					<input type="checkbox" class="sheet-block-switch"><span>Importer statblock</span>
+					<div class="sheet-block-hidden"></div>
+					<div class="sheet-block-show">
+    		            <textarea name="attr_statblock" style="height: 10em;" placeholder="Coller ici un statblock copié depuis le PDF"></textarea>
+    		            &nbsp;
+    		            <textarea name="attr_sbresult" style="height: 5em;"></textarea>
                     </div>
-                </div>
-            </fieldset>
-    	</div>
-    	<img class="sheet-imghr" src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/ChroniquesGalactiques/cog_hr.png" />
-    </div>
-    <div class="sheet-tab-content sheet-tab2">
-        <div> <!-- Voies -->
-            <table>
-                <tr><td class="sheet-textfatleft" COLSPAN="5">CAPACIT&Eacute;S DU PERSONNAGE</td></tr>
-                <tr>
-                    <td class="sheet-boxtitresmall" style="width: 20px;">&nbsp;</td>
-                    <td class="sheet-boxtitresmall">Voie 1</td>
-                    <td class="sheet-boxtitresmall">Voie 2</td>
-                    <td class="sheet-boxtitresmall">Voie 3</td>
-                </tr>
-                <tr>
-                    <td class="sheet-boxtitresmall">R</td>
-                    <td class="sheet-boxinputleft"><input type="text" style="font-weight: bold;text-align: center;" name="attr_voie1nom" title="@{voie1nom}" placeholder="Nom de la Voie n°1" /></td>
-                    <td class="sheet-boxinput"><input type="text" style="font-weight: bold;text-align: center;" name="attr_voie2nom" placeholder="Nom de la Voie n°2" /></td>
-                    <td class="sheet-boxinput"><input type="text" style="font-weight: bold;text-align: center;" name="attr_voie3nom" placeholder="Nom de la Voie n°3" /></td>
-                </tr>
-                <tr>
-                    <td class="sheet-boxtitresmall">1</td>
-                    <td class="sheet-boxvoie"><textarea name="attr_voie1-1" title="@{voie1-1}"></textarea></td>
-                    <td class="sheet-boxvoie"><textarea name="attr_voie2-1"></textarea></td>
-                    <td class="sheet-boxvoie"><textarea name="attr_voie3-1"></textarea></td>
-                </tr>
-                <tr>
-                    <td class="sheet-boxtitresmall">2</td>
-                    <td class="sheet-boxvoie"><textarea name="attr_voie1-2" title="@{voie1-2}"></textarea></td>
-                    <td class="sheet-boxvoie"><textarea name="attr_voie2-2"></textarea></td>
-                    <td class="sheet-boxvoie"><textarea name="attr_voie3-2"></textarea></td>
-                </tr>
-                <tr>
-                    <td class="sheet-boxtitresmall">3</td>
-                    <td class="sheet-boxvoie"><textarea name="attr_voie1-3" title="@{voie1-3}"></textarea></td>
-                    <td class="sheet-boxvoie"><textarea name="attr_voie2-3"></textarea></td>
-                    <td class="sheet-boxvoie"><textarea name="attr_voie3-3"></textarea></td>
-                </tr>
-                <tr>
-                    <td class="sheet-boxtitresmall">4</td>
-                    <td class="sheet-boxvoie"><textarea name="attr_voie1-4" title="@{voie1-4}"></textarea></td>
-                    <td class="sheet-boxvoie"><textarea name="attr_voie2-4"></textarea></td>
-                    <td class="sheet-boxvoie"><textarea name="attr_voie3-4"></textarea></td>
-                </tr>
-                <tr>
-                    <td class="sheet-boxtitresmall">5</td>
-                    <td class="sheet-boxvoie"><textarea name="attr_voie1-5"title="@{voie1-5}"></textarea></td>
-                    <td class="sheet-boxvoie"><textarea name="attr_voie2-5"></textarea></td>
-                    <td class="sheet-boxvoie"><textarea name="attr_voie3-5"></textarea></td>
-                </tr>
-            </table>
-            <table>
-                <tr>
-                    <td class="sheet-boxtitresmall" style="width: 20px;">&nbsp;</td>
-                    <td class="sheet-boxtitresmall">Voie 4</td>
-                    <td class="sheet-boxtitresmall">Voie 5</td>
-                    <td class="sheet-boxtitresmall">Voie 6</td>
-                </tr>
-                <tr>
-                    <td class="sheet-boxtitresmall">R</td>
-                    <td class="sheet-boxinputleft"><input type="text" style="font-weight: bold;text-align: center;" name="attr_voie4nom" placeholder="Nom de la Voie n°4" /></td>
-                    <td class="sheet-boxinput"><input type="text" style="font-weight: bold;text-align: center;" name="attr_voie5nom" placeholder="Nom de la Voie n°5" /></td>
-                    <td class="sheet-boxinput"><input type="text" style="font-weight: bold;text-align: center;" name="attr_voie6nom" placeholder="Nom de la Voie n°6" /></td>
-                </tr>
-                <tr>
-                    <td class="sheet-boxtitresmall">1</td>
-                    <td class="sheet-boxvoie"><textarea name="attr_voie4-1"></textarea></td>
-                    <td class="sheet-boxvoie"><textarea name="attr_voie5-1"></textarea></td>
-                    <td class="sheet-boxvoie"><textarea name="attr_voie6-1"></textarea></td>
-                </tr>
-                <tr>
-                    <td class="sheet-boxtitresmall">2</td>
-                    <td class="sheet-boxvoie"><textarea name="attr_voie4-2"></textarea></td>
-                    <td class="sheet-boxvoie"><textarea name="attr_voie5-2"></textarea></td>
-                    <td class="sheet-boxvoie"><textarea name="attr_voie6-2"></textarea></td>
-                </tr>
-                <tr>
-                    <td class="sheet-boxtitresmall">3</td>
-                    <td class="sheet-boxvoie"><textarea name="attr_voie4-3"></textarea></td>
-                    <td class="sheet-boxvoie"><textarea name="attr_voie5-3"></textarea></td>
-                    <td class="sheet-boxvoie"><textarea name="attr_voie6-3"></textarea></td>
-                </tr>
-                <tr>
-                    <td class="sheet-boxtitresmall">4</td>
-                    <td class="sheet-boxvoie"><textarea name="attr_voie4-4"></textarea></td>
-                    <td class="sheet-boxvoie"><textarea name="attr_voie5-4"></textarea></td>
-                    <td class="sheet-boxvoie"><textarea name="attr_voie6-4"></textarea></td>
-                </tr>
-                <tr>
-                    <td class="sheet-boxtitresmall">5</td>
-                    <td class="sheet-boxvoie"><textarea name="attr_voie4-5"></textarea></td>
-                    <td class="sheet-boxvoie"><textarea name="attr_voie5-5"></textarea></td>
-                    <td class="sheet-boxvoie"><textarea name="attr_voie6-5"></textarea></td>
-                </tr>
-            </table>
-            <div>
-                <input type="checkbox" class="sheet-block-switch" name="attr_voies789" title="@{voies789}" value="1"><span>Plus de voies</span>
-                <div class="sheet-block-hidden"></div>
-                <div class="sheet-block-show">
-                    <table>
-                        <tr>
-                            <td class="sheet-boxtitresmall" style="width: 20px;">&nbsp;</td>
-                            <td class="sheet-boxtitresmall">Voie 7</td>
-                            <td class="sheet-boxtitresmall">Voie 8</td>
-                            <td class="sheet-boxtitresmall">Voie 9</td>
-                        </tr>
-                        <tr>
-                            <td class="sheet-boxtitresmall">R</td>
-                            <td class="sheet-boxinputleft"><input type="text" style="font-weight: bold;text-align: center;" name="attr_voie7nom" placeholder="Nom de la Voie n°7" /></td>
-                            <td class="sheet-boxinput"><input type="text" style="font-weight: bold;text-align: center;" name="attr_voie8nom" placeholder="Nom de la Voie n°8" /></td>
-                            <td class="sheet-boxinput"><input type="text" style="font-weight: bold;text-align: center;" name="attr_voie9nom" placeholder="Nom de la Voie n°9" /></td>
-                        </tr>
-                        <tr>
-                            <td class="sheet-boxtitresmall">1</td>
-                            <td class="sheet-boxvoie"><textarea name="attr_voie7-1"></textarea></td>
-                            <td class="sheet-boxvoie"><textarea name="attr_voie8-1"></textarea></td>
-                            <td class="sheet-boxvoie"><textarea name="attr_voie9-1"></textarea></td>
-                        </tr>
-                        <tr>
-                            <td class="sheet-boxtitresmall">2</td>
-                            <td class="sheet-boxvoie"><textarea name="attr_voie7-2"></textarea></td>
-                            <td class="sheet-boxvoie"><textarea name="attr_voie8-2"></textarea></td>
-                            <td class="sheet-boxvoie"><textarea name="attr_voie9-2"></textarea></td>
-                        </tr>
-                        <tr>
-                            <td class="sheet-boxtitresmall">3</td>
-                            <td class="sheet-boxvoie"><textarea name="attr_voie7-3"></textarea></td>
-                            <td class="sheet-boxvoie"><textarea name="attr_voie8-3"></textarea></td>
-                            <td class="sheet-boxvoie"><textarea name="attr_voie9-3"></textarea></td>
-                        </tr>
-                        <tr>
-                            <td class="sheet-boxtitresmall">4</td>
-                            <td class="sheet-boxvoie"><textarea name="attr_voie7-4"></textarea></td>
-                            <td class="sheet-boxvoie"><textarea name="attr_voie8-4"></textarea></td>
-                            <td class="sheet-boxvoie"><textarea name="attr_voie9-4"></textarea></td>
-                        </tr>
-                        <tr>
-                            <td class="sheet-boxtitresmall">5</td>
-                            <td class="sheet-boxvoie"><textarea name="attr_voie7-5"></textarea></td>
-                            <td class="sheet-boxvoie"><textarea name="attr_voie8-5"></textarea></td>
-                            <td class="sheet-boxvoie"><textarea name="attr_voie9-5"></textarea></td>
-                        </tr>
-                    </table>
-                </div>
-            </div>
-            <img class="sheet-imghr" src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/ChroniquesGalactiques/cog_hr.png" />
-            <table class="sheet-tabsep" title="repeating_jetcapas">
-                <tr>
-                    <td class="sheet-textfatleft" style="min-width:245px;">Jets de Capacités</td>
-                    <td class="sheet-textbase" style="width:100%;">&nbsp;</td>
-                </tr>
-            </table>
-            <fieldset class="repeating_jetcapas">
-                <table  class="sheet-tabsep">
-                    <tr>
-                        <td>
-                            <button type="roll" class="sheet-neutre" name="attr_jet" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=@{jetcapanom}}} {{subtags=Capacité}} {{carac=[[@{jetcapanbde}d@{jetcapade}@{jetcapatypjet} + [[@{jetcapacarac}]] + @{jetcapadiv}]] }} {{desc=@{jetcapadesc}}}" />
-                        </td>
-                        <td class="sheet-boxinputleft" style="min-width:200px;">
-                            <input type="text" name="attr_jetcapanom" title="@{jetcapanom}" style="font-weight: bold;" placeholder="Nom du Jet de capacité" />
-                        </td>
-                        <td class="sheet-textbase"  style="text-align: right;">
-                            Jet
-                        </td>
-                        <td class="sheet-boxinputleft">
-                            <input type="number" style="width:32px;" name="attr_jetcapanbde" value="1" title="@{jetcapanbde} Nombre de dés" />
-                            <select class="sheet-carac"  style="width:50px;" name="attr_jetcapade" size="1" title="@{jetcapade} Dé (d20 => d12 si Affaibli)">
-                                <option value="4">d4</option>
-                                <option value="6">d6</option>
-                                <option value="8">d8</option>
-                                <option value="10">d10</option>
-                                <option value="12">d12</option>
-                                <option value="@{ETATDE}" selected>d20 (ou d12 si Affaibli)</option>
-                            </select>
-                            (<select class="sheet-carac" style="width:30px;" name="attr_jetcapatypjet" size="1" title="@{jetcapatypjet} Option du jet : normal, meilleur dé, moins bon dé, sans limite">
-                                <option value="">N - Normal</option>
-                                <option value="kh1">S - Garder le meilleur dé</option>
-                                <option value="kl1">I - Garder le moins bon dé</option>
-                                <option value="!">E - Explosif (jet sans limite)</option>
-                            </select>)
-    						+<select class="sheet-carac" style="width:50px;" name="attr_jetcapacarac" size="1" title="@{jetcapacarac} Modificateur du jet">
-                                <option value="0">-</option>
-                                <optgroup label="Mod. de base">
-                                    <option value="@{FOR}" selected>FOR</option>
-                                    <option value="@{DEX}">DEX</option>
-                                    <option value="@{CON}">CON</option>
-                                    <option value="@{INT}">INT</option>
-                                    <option value="@{PER}">PER</option>
-                                    <option value="@{CHA}">CHA</option>
-                                </optgroup>
-                                    <optgroup label="Mod. de test">
-                                    <option value="@{FOR_TEST}">FOR</option>
-                                    <option value="@{DEX_TEST}">DEX</option>
-                                    <option value="@{CON_TEST}">CON</option>
-                                    <option value="@{INT_TEST}">INT</option>
-                                    <option value="@{PER_TEST}">PER</option>
-                                    <option value="@{CHA_TEST}">CHA</option>
-                                </optgroup>
-                                <optgroup label="Attaques">
-                                    <option value="@{ATKCAC}">ATC</option>
-                                    <option value="@{ATKTIR}">ATD</option>
-                                    <option value="@{ATKPSYINFLU}">Influ. Psy</option>
-                                    <option value="@{ATKPSYINTUI}">Intui. Psy</option>
-                                </optgroup>
-                            </select>+<input type="number" style="width:32px;" name="attr_jetcapadiv" value="0" title="@{jetcapadiv} Bonus divers" />
-                        </td>
-                        <td class="sheet-textbase"  style="text-align: right;">
-                            Desc.
-                        </td>
-                        <td class="sheet-boxinputleft" style="width:100%;">
-                            <textarea name="attr_jetcapadesc" placeholder="Description" title="@{jetcapadesc}"></textarea>
-                        </td>
-                    </tr>
-                </table>
-            </fieldset>
-        </div> <!-- FIN Voies -->
-        <img class="sheet-imghr" src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/ChroniquesGalactiques/cog_hr.png" />
-        <div>
-            <input type="checkbox" class="sheet-block-switch" name="attr_voir_traits"><span class="sheet-textbase">Autres traits</span>
-            <div class="sheet-block-hidden"></div>
-            <div class="sheet-block-show">
-                <fieldset class="repeating_traits">
-                    <table class="sheet-tabsep">
-                        <tr>
-                            <td style="width: 15px;">
-                                <button type="roll" name="attr_chat" class="sheet-output" value='/w "@{character_name}" &{template:co1} {{perso=@{character_name}}} {{name=@{traitnom}}} {{subtags=@{traittype}}} {{text=@{traitdesc}}}'>w</button>
-                            </td>
-                            <td class="sheet-boxinputleft" style="width: 200px;"><input type="text" style="font-weight: bold;" name="attr_traitnom" placeholder="Nom du trait" title="@{traitnom}" /></td>
-                            <td class="sheet-boxinputleft" style="width: 150px;"><input type="text" name="attr_traittype" placeholder="Origine/Type de trait" title="@{traittype}" /></td>
-                            <td class="sheet-boxinputleft"><textarea name="attr_traitdesc" placeholder="Description" title="@{traitdesc}"></textarea></td>
-                        </tr>
-                    </table>
-                </fieldset>
-                <img class="sheet-imghr" src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/ChroniquesOublieesContemporain/coc_hr.jpg" />
-            </div>
-        </div>
-    </div>
-    <div class="sheet-tab-content sheet-tab3">
-        <div> <!-- Equipement et règles optionnelles -->
-            <div class="sheet-2colrow">
-                <div class="sheet-col" title="repeating_equipement">
-                    <div class="sheet-boxtitre">&Eacute;QUIPEMENT : Consommables</div>
-                    <div class="sheet-boxinputleft">
-                        <span class="textbase">Crédits&nbsp;:</span>&nbsp;
-                        <input type="text" style="width:320px;" name="attr_RICHESSE" title="@{RICHESSE}" placeholder="Rien ? C'est la pauvret&eacute; !" />
-                    </div>
-                    <fieldset class="repeating_equipement">
-                        <div class="sheet-boxvoie">
-                            <input type="text" style="width:310px;" name="attr_equip-nom" title="@{equip-nom}" />
-                            &nbsp;<span class="sheet-textbase">Qt&eacute;</span>
-                            <input type="number" name="attr_equip-qte" value="1" title="@{equip-qte}" />
-                        </div>
-                    </fieldset>
-                </div>
-                <div class="sheet-col" title="repeating_materiel">
-                    <div class="sheet-boxtitre">&Eacute;QUIPEMENT : Personnel</div>
-                    <fieldset class="repeating_materiel">
-                        <div class="sheet-boxvoie">
-                            <input type="text" name="attr_mater-nom" title="@{mater-nom}" />
-                        </div>
-                    </fieldset>
-                </div>
-            </div>
-            <img class="sheet-imghr" src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/ChroniquesGalactiques/cog_hr.png" />
-            <div class="sheet-2colrow">
-                <div class="sheet-col">
-                    <table>
-                        <tr><td class="sheet-boxtitre">&Eacute;QUIPEMENT : Divers</td></tr>
-                        <tr><td class="sheet-boxinputleft"><textarea name="attr_equip-div" style="height:15em;" title="@{equip-div}"></textarea></td></tr>
-                    </table>
-                </div>
-                <div class="sheet-col">
-                    <table>
-                        <tr><td class="sheet-boxtitre">Notes</td></tr>
-                        <tr><td class="sheet-boxinputleft"><textarea name="attr_notes" style="height:15em;" title="@{notes}"></textarea></td></tr>
-                    </table>
-                </div>
-            </div>
-            <img class="sheet-imghr" src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/ChroniquesGalactiques/cog_hr.png" />    
-        </div> <!-- FIN Equipement et règles optionnelles -->
-    </div>
-    <div class="sheet-tab-content sheet-tabv">
-        <div> <!-- Caracs + combat + PV + défense -->
-            <table>
-                <tr>
-                    <td style="width:250px; vertical-align: top;"> <!-- Caracs + Chance -->
-                        <table class="sheet-tabsep"> <!-- Caracs -->
-                            <tr>
-                                <td class="sheet-textfat">CARAC.</td>
-                                <td></td>
-                                <td class="sheet-textbase">Valeur</td>
-                                <td class="sheet-textfat">Mod.</td>
-                                <td class="sheet-textbase">Bonus</td>
-                                <td class="sheet-textfat">Test</td>
-                            </tr>
-                            <tr>
-                                <td class="sheet-boxtitre" colspan="2"><button class="sheet-boxtitre" type="roll" name="JET_FOR" title="Jet de Puissance" value="@(togm}&{template:co1} {{perso=@{character_name}}} {{name=Puissance}} {{subtags=Test}} {{carac=[[ 1d20cs20cf1[Dé] + [[@{FOR_TEST}]][Puissance] + @{POSTE_MOT} ]] }}"> FOR</button></td>
-                                <td class="sheet-boxinput"><input type="number" name="attr_FORCE" title="@{FORCE}" value="10" min="0" /></td>
-                                <td class="sheet-boxinputlight"><input type="number" name="attr_FOR" title="@{FOR}" value="floor((@{FORCE}-10)/2)" disabled /></td>
-                                <td class="sheet-boxinputlight"><input type="number" name="attr_FOR_BONUS" title="@{FOR_BONUS} Bonus au Test" value="@{FOR_BUFF}" disabled /></td>
-                                <td class="sheet-boxinputlight"><input type="number" name="attr_FOR_TEST" title="@{FOR_TEST}" value="@{FOR}+@{FOR_BONUS}" disabled /></td>
-                            </tr>
-                            <tr>
-                                <td class="sheet-boxtitre" colspan="2"><button class="sheet-boxtitre" type="roll" name="JET_DEX" title="Jet de Manoeuvrabilit&eacute;" value="@(togm}&{template:co1} {{perso=@{character_name}}} {{name=Manoeuvrabilit&eacute;}} {{subtags=Test}} {{carac=[[ 1d20cs20cf1[Dé] + [[@{DEX_TEST}]][Manoeuvrabilit&eacute;] + @{POSTE_PIL} ]] }}"> DEX</button></td>
-                                <td class="sheet-boxinput"><input type="number" name="attr_DEXTERITE" title="@{DEXTERITE}" value="10" min="0"  /></td>
-                                <td class="sheet-boxinputlight"><input type="number" name="attr_DEX" title="@{DEX}" value="floor((@{DEXTERITE}-10)/2)" disabled /></td>
-                                <td class="sheet-boxinputlight"><input type="number" name="attr_DEX_BONUS" title="@{DEX_BONUS} Bonus au Test" value="@{DEX_BUFF}" disabled /></td>
-                                <td class="sheet-boxinputlight"><input type="number" name="attr_DEX_TEST" title="@{DEX_TEST}" value="@{DEX}+@{DEX_BONUS}" disabled /></td>
-                            </tr>
-                            <tr>
-                                <td class="sheet-boxtitre" colspan="2"><button class="sheet-boxtitre" type="roll" name="JET_CON" title="Jet de Coque" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=Coque}} {{subtags=Test}} {{carac=[[ 1d20cs20cf1[Dé] + [[@{CON_TEST}]][Bonus] ]] }}"> CON</button></td>
-                                <td class="sheet-boxinput"><input type="number" name="attr_CONSTITUTION" title="@{CONSTITUTION}" value="10" min="0"  /></td>
-                                <td class="sheet-boxinputlight"><input type="number" name="attr_CON" title="@{CON}" value="floor((@{CONSTITUTION}-10)/2)" disabled /></td>
-                                <td class="sheet-boxinputlight"><input type="number" name="attr_CON_BONUS" title="@{CON_BONS} Bonus au Test" value="@{CON_BUFF}" disabled /></td>
-                                <td class="sheet-boxinputlight"><input type="number" name="attr_CON_TEST" title="@{CON_TEST}" value="@{CON}+@{CON_BONUS}" disabled /></td>
-                            </tr>
-                            <tr>
-                                <td class="sheet-boxtitre" colspan="2"><button class="sheet-boxtitre" type="roll" name="JET_INT" title="Jet d'Ordinateurs de Vis&eacute;e" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=Ordinateur de Visée}} {{subtags=Test}} {{carac=[[ 1d20cs20cf1[Dé] + [[@{INT_TEST}]][Bonus] ]] }}"> INT</button></td>
-                                <td class="sheet-boxinput"><input type="number" name="attr_INTELLIGENCE" title="@{INTELLIGENCE}" value="10" min="0"  /></td>
-                                <td class="sheet-boxinputlight"><input type="number" name="attr_INT" title="@{INT}" value="floor((@{INTELLIGENCE}-10)/2)" disabled /></td>
-                                <td class="sheet-boxinputlight"><input type="number" name="attr_INT_BONUS" title="@{INT_BONUS} Bonus au Test" value="@{INT_BUFF}" disabled /></td>
-                                <td class="sheet-boxinputlight"><input type="number" name="attr_INT_TEST" title="@{INT_TEST}" value="@{INT}+@{INT_BONUS}" disabled /></td>
-                            </tr>
-                            <tr>
-                                <td class="sheet-boxtitre" colspan="2"><button class="sheet-boxtitre" type="roll" name="JET_PER" title="Jet de Senseurs" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=Senseurs}} {{subtags=Test}} {{carac=[[ 1d20cs20cf1[Dé] + [[@{PER_TEST}]][Senseurs] + @{POSTE_SEN} ]] }}"> PER</button></td>
-                                <td class="sheet-boxinput"><input type="number" name="attr_PERCEPTION" title="@{PERCEPTION}" value="10" min="0"  /></td>
-                                <td class="sheet-boxinputlight"><input type="number" name="attr_PER" title="@{PER}" value="floor((@{PERCEPTION}-10)/2)" disabled /></td>
-                                <td class="sheet-boxinputlight"><input type="number" name="attr_PER_BONUS" title="@{PER_BONUS} Bonus au Test" value="@{PER_BUFF}" disabled /></td>
-                                <td class="sheet-boxinputlight"><input type="number" name="attr_PER_TEST" title="@{PER_TEST}" value="@{PER}+@{PER_BONUS}" disabled /></td>
-                            </tr>
-                            <tr>
-                                <td class="sheet-boxtitre" colspan="2"><button class="sheet-boxtitre" type="roll" name="JET_CHA" title="Jet de Communications" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=Communications}} {{subtags=Test}} {{carac=[[ 1d20cs20cf1[Dé] + [[@{CHA_TEST}]][Comm.Systèmes] + @{POSTE_ORD} ]] }}"> CHA</button></td>
-                                <td class="sheet-boxinput"><input type="number" name="attr_CHARISME" title="@{CHARISME}" value="10" min="0"  /></td>
-                                <td class="sheet-boxinputlight"><input type="number" name="attr_CHA" title="@{CHA}" value="floor((@{CHARISME}-10)/2)" disabled /></td>
-                                <td class="sheet-boxinputlight"><input type="number" name="attr_CHA_BONUS" title="@{CHA_BONUS} Bonus au Test" value="@{CHA_BUFF}" disabled /></td>
-                                <td class="sheet-boxinputlight"><input type="number" name="attr_CHA_TEST" title="@{CHA_TEST}" value="@{CHA}+@{CHA_BONUS}" disabled /></td>
-                            </tr>
-                        </table> <!-- FIN Caracs -->
-                        <table class="sheet-tabsep" style="margin-top: 20px;"> <!-- Energie -->
-                            <tr>
-                                <td class="sheet-boxtitre" title="Points d'énergie">PE</td>
-                                <td class="sheet-boxinput"><input type="number" name="attr_PEV" value="0" title="@{PEV} Points d'énergie utilisés ou courants" /></td>
-                                <td>/</td>
-                                <td class="sheet-boxinputlight"><input type="number" name="attr_PEVBASE" title="@{PEVBASE} Points d'énergie de base" value="@{NIVEAU}" disabled /></td>
-                                <td>+</td>
-                                <td class="sheet-boxinputlight"><input type="number" name="attr_PEVDIV" title="@{PEVDIV} Points d'énergie additionnels" value="@{PEV_BUFF}" disabled/></td>
-                                <td>+</td>
-                                <td class="sheet-boxinputlight"><INPUT type="number" name="attr_PEVCAR" value="@{FOR}" title="@{PEVCAR} Mod. de puissance (FOR)" disabled /></td>
-                                <td>=</td>
-                                <td class="sheet-boxinputlight"><input type="number" name="attr_PEV_max" value="@{PEVBASE}+@{PEVDIV}+@{PEVCAR}" title="Points d'énergie maximums" disabled /></td>
-                            </tr>
-                        </table> <!-- FIN Energie -->
-                    </td> <!-- FIN Caracs + Chance -->
-                    <td  style="width:100%; vertical-align: top;"> <!-- Combat + PV + défense -->
-                        <table>
-                            <tr>
-                                <td style="vertical-align: top;"> <!-- Combat -->
-                                    <table class="sheet-tabsep">
-                                        <tr>
-                                            <td class="sheet-textfat">COMBAT</td>
-                                            <td class="sheet-textbase">Base</td>
-                                            <td class="sheet-textbase">Mod.</td>
-                                            <td class="sheet-textbase">Div.</td>
-                                            <td class="sheet-textfat">Total</td>
-                                        </tr>
-                                        <tr>
-                                            <td class="sheet-boxtitre"><button class="sheet-boxtitre" type="roll" name="JET_TIRV" title="Jet d'attaque à distance" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=&Agrave; Distance}} {{subtags=Attaque}} {{attaque=[[ 1d20cs20cf1[Dé] + [[@{ATKTIRV}]][Bonus] ]] }}"> &Agrave; DISTANCE</button></td>
-                                            <td class="sheet-boxinputlight"><input type="number" name="attr_ATKTIRV_BASE" value="@{NIVEAU}" title="@{ATKTIRV_BASE} Score de base" disabled /></td>
-                                            <td class="sheet-boxinput">
-                                                <select class="sheet-carac" name="attr_ATKTIRV_CARAC" size="1" title="@{ATKTIRV_CARAC}">
-                                                    <option value="@{INT}" selected>INT</option>
-                                                </select>
-                                            </td>
-                                            <td class="sheet-boxinputlight"><input type="number" name="attr_ATKTIRV_DIV" title="@{ATKTIRV_DIV} Bonus divers" value="@{ATKTIRV_BUFF}" disabled /></td>
-                                            <td class="sheet-boxinputlight"><input type="number" name="attr_ATKTIRV" title="@{ATKTIRV}" value="@{ATKTIRV_BASE}+@{ATKTIRV_CARAC}+@{ATKTIRV_DIV}" disabled /></td>
-                                        </tr>
-                                        <tr>
-                                            <td class="sheet-boxtitre" title="Poste de pilotage (PIL)">Pilotage</td>
-                                            <td class="sheet-boxinput" colspan="4"><input type="text" name="attr_POSTE_PIL" title="@{POSTE_PIL}" placeholder="[[@{Nom du pilote|DEX}]][DEX pilote] +Bonus/Rang[Pilotage]" /></td>
-                                        </tr>
-                                        <tr>
-                                            <td class="sheet-boxtitre" title="Salle des machines (MOT)">Machines</td>
-                                            <td class="sheet-boxinput" colspan="4"><input type="text" name="attr_POSTE_MOT" title="@{POSTE_MOT}" placeholder="[[@{Nom du mécanicien|INT}]][INT mécano] +Bonus/Rang[Moteurs]" /></td>
-                                        </tr>
-                                        <tr>
-                                            <td class="sheet-boxtitre" title="Console des senseurs (SEN)">Senseurs</td>
-                                            <td class="sheet-boxinput" colspan="4"><input type="text" name="attr_POSTE_SEN" title="@{POSTE_SEN}" placeholder="[[@{Nom du scantech|INT}]][INT scantech] +Bonus/Rang[Electronique]" /></td>
-                                        </tr>
-                                        <tr>
-                                            <td class="sheet-boxtitre" title="Console du système (ORD)">Ordinateurs</td>
-                                            <td class="sheet-boxinput" colspan="4"><input type="text" name="attr_POSTE_ORD" title="@{POSTE_ORD}" placeholder="[[@{Nom de l'infotech|INT}]][INT infotech] +Bonus/Rang[Electronique]" /></td>
-                                        </tr>
-                                        <tr>
-                                            <td class="sheet-boxtitre"><button class="sheet-boxtitre" type="roll" name="JET_INIT" title="Initiative" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=Initiative}} {{subtags=Combat}} {{carac=[[@{INITV}[Initiative] + @{INIT_VAR}[Dé(s)] &{tracker}]]}}"> INITIATIVE</button></td>
-                                            <td>&nbsp;</td>
-                                            <td class="sheet-boxinputlight"><input type="number" name="attr_INITV_CARAC" title="@{INITV_CARAC}" value="@{DEX}" disabled /></td>
-                                            <td class="sheet-boxinputlight"><input type="number" name="attr_INITV_PIL" title="@{INITV_PIL} Valeur de DEX du pilote" value="@{INIT_BUFF}" disabled /></td>
-                                            <td class="sheet-boxinputlight"><input type="number" name="attr_INITV" title="@{INITV}" value="@{INITV_CARAC}+@{INITV_PIL}" disabled /></td>
-                                        </tr>
-                                    </table>
-                                </td> <!-- FIN Combat -->
-                                <td style="vertical-align: top;"> <!-- PV -->
-                                    <table class="sheet-tabsep">
-                                        <tr>
-                                            <td class="sheet-textfat" colspan="2">STRUCTURE</td>
-                                        </tr>
-                                        <tr>
-                                            <td class="sheet-boxtitre">DV</button></td>
-                                            <td class="sheet-boxinput">
-                                                <select class="sheet-carac" name="attr_DV" size="1" title="@{DV} D&eacute; de Structure">
-                                                    <option value="0" selected >-</option>
-                                                    <option value="4">d4</option>
-                                                    <option value="6">d6</option>
-                                                    <option value="8">d8</option>
-                                                    <option value="10">d10</option>
-                                                    <option value="12">d12</option>
-                                                </select>
-                                            </td>
-                                        </tr>
-                                        <tr>
-                                            <td class="sheet-boxtitre">PV</button></td>
-                                            <td class="sheet-boxinput"><input type="number" name="attr_PV_max" title="@{PV|max} Points de Structure maximum"  value="0" /></td>
-                                        </tr>
-                                        <tr>
-                                            <td  class="sheet-boxinput" COLSPAN="2">
-                                                <span class="textbase">PV restants</span>&nbsp;
-                                                <input type="number" name="attr_PV" title="@{PV} Points de Structure restants" value="0" />
-                                            </td>
-                                        </tr>
-                                        <tr>
-                                            <td  class="sheet-boxinput" COLSPAN="2">
-                                                <span class="textbase">DM temp.</span>&nbsp;
-                                                <input type="number" name="attr_DMTEMP" title="@{DMTEMP} Dommages EMP"  value="0" />
-                                            </td>
-                                        </tr>
-                                        <tr>
-                                            <td class="sheet-boxtitre" title="Boucliers (réduction des dommages)">RD</td>
-                                            <td class="sheet-boxinput"><input type="number" name="attr_RD" title="@{RD} Réduction des dommages" value="0" /></td>
-                                        </tr>
-                                        <tr><td>&nbsp;</td></tr>
-                                    </table>
-                                </td> <!-- FIN PV -->
-                            </tr>
-                            <tr>
-                                <td colspan="2"  style="vertical-align: top;"> <!-- Défense -->
-                                    <table class="sheet-tabsep">
-                                        <tr>
-                                            <td class="sheet-textfat">D&Eacute;FENSES</td>
-                                            <td>&nbsp;</td>
-                                            <td class="sheet-textbase">Mod. DEX/CON</td>
-                                            <td class="sheet-textbase">Pilote</td>
-                                            <td class="sheet-textbase">Mod. PER</td>
-                                            <td class="sheet-textbase">Scantech</td>
-                                            <td class="sheet-textfat">Total</td>
-                                        </tr>
-                                        <tr>
-                                            <td class="sheet-boxtitre">DEF (rapidité)</td>
-                                            <td class="sheet-boxinputlight">10+</td>
-                                            <td class="sheet-boxinputlight"><input type="number" name="attr_DEFVDEX" value="@{DEX}" title="@{DEFVDEX} Bonus de Manoeuvrabilit&eacute;" disabled /></td>
-                                            <td class="sheet-boxinputlight"><input type="number" name="attr_DEFVPIL" value="@{DEFVPIL_BUFF}" title="@{DEFVPIL} Bonus du Pilote" disabled /></td>
-                                            <td class="sheet-boxinputlight"><input type="number" name="attr_DEFVPER" value="@{PER}" title="@{DEFVPER} Bonus de Senseurs" disabled /></td>
-                                            <td class="sheet-boxinputlight"><input type="number" name="attr_DEFVSEN" value="@{DEFVSEN_BUFF}" title="@{DEFVSEN} Bonus du Scantech" disabled /></td>
-                                            <td class="sheet-boxinputlight"><input type="number" name="attr_DEFRAP" value="10+@{DEFVDEX}+@{DEFVPIL}+@{DEFVPER}+@{DEFVSEN}" title="@{DEFRAP} D&eacute;fense (rapidit&eacute;)" disabled /></td>
-                                        </tr>
-                                        <tr>
-                                            <td class="sheet-boxtitre">DEF (solidité)</td>
-                                            <td class="sheet-boxinputlight">10+</td>
-                                            <td class="sheet-boxinputlight"><input type="number" name="attr_DEFVCON" value="@{CON}" title="@{DEFVCON} Bonus de Coque" disabled /></td>
-                                            <td class="sheet-textbase">&nbsp;</td>
-                                            <td class="sheet-textbase">&nbsp;</td>
-                                            <td class="sheet-textbase">&nbsp;</td>
-                                            <td class="sheet-boxinputlight"><input type="number" name="attr_DEFSOL" value="10+@{DEFVCON}+@{DEFVPER}+@{DEFVSEN}" title="@{DEFSOL} D&eacute;fense (solidit&eacute;)" disabled /></td>
-                                        </tr>
-                                    </table>
-                                </td>
-                            </tr>
-                        </table>
-                    </td> <!-- FIN Combat + PV + défense -->
-                </tr>
-            </table>
-        </div> <!-- FIN Caracs + combat + PV + défense  -->
-        <img class="sheet-imghr" src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/ChroniquesGalactiques/cog_hr.png" />
-    	<div> <!-- Armes -->
-    		<table class="sheet-tabsep" title="repeating_armesv">
-    			<tr>
-    				<td class="sheet-textfatleft" style="width:155px;">ARMES / ATTAQUES</td>
-    				<td class="sheet-textbase" style="width:140px;">ATTAQUE</td>
-    				<td class="sheet-textbase" style="width:20px;">CRIT.</td>
-    				<td class="sheet-textbase" style="width:185px;">DM</td>
-    				<td class="sheet-textbase" style="widht:100%;">SPÉCIAL</td>
-    			</tr>
-            </table>
-    		<div style="max-height:170px;overflow-y:scroll;">
-    			<fieldset class="repeating_armesv">
-                    <div class="attack">
-                        <input class="options-flag" name="attr_armeoptflag" type="checkbox" title="Montrer/cacher les options"><span>y</span>
-                        <div>
-                            <table  class="sheet-tabsep">
-            					<tr>
-            						<td>
-            							<button type="roll" class="sheet-neutre" name="JetArme" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=@{armenom}}} {{subtags=Attaque}} {{desc=@{armejetn}}} {{attaque=[[@{armejetd}cs>@{armecrit}cf<@{armeinct}[Dé] + [[@{armeatk}]][Attaque] + @{armecan} + @{armeatkdiv}[Bonus] ]]}} {{degats=[[@{armedmnbde}d@{armedmde}[Dé DM] + [[@{armedmcar}]][Mod.DM] + @{armedmdiv}[Bonus DM] ]]}} {{special=@{armespec}}}" />
-            						</td>
-            						<td class="sheet-boxinputleft" style="min-width: 130px;">
-            							<input type="text" name="attr_armenom" title="@{armenom}" style="font-weight: bold;" placeholder="Arme/attaque"/>
-            						</td>
-            						<td class="sheet-boxinputleft" style="min-width: 145px;">
-            								<select class="sheet-carac" style="width: 87px;" name="attr_armeatk" title="@{armeatk}" size="1">
-            									<option value="@{ATKTIRV}" selected>DISTANCE</option>
-            								</select>+<input type="number" style="width:32px;" name="attr_armeatkdiv" value="0" title="@{armeatkdiv} Bonus d'attaque divers" />
-            						</td>
-            						<td class="sheet-boxinputleft" style="text-align: right;">
-            							<input type="number" name="attr_armecrit" style="width:32px;" min="2" max="20" value="20" title="@{armecrit} Seuil de Critique (par défaut 20)" />
-            						</td>
-            						<td class="sheet-boxinputleft">
-            							<input type="number" style="width:32px;" name="attr_armedmnbde" value="1" title="@{armedmnbde} Nombre de dés de dommage" />
-            							<select class="sheet-carac"  style="width:47px;" name="attr_armedmde" size="1" title="@{armedmde} Dé de dommage">
-            								<option value="4">d4</option>
-            								<option value="6" selected>d6</option>
-            								<option value="8">d8</option>
-            								<option value="10">d10</option>
-            								<option value="12">d12</option>
-            							</select>+<select class="sheet-carac" style="width:52px;" name="attr_armedmcar" size="1" title="@{armedmcar} Modificateur aux dommages">
-            								<option value="0">-</option>
-            								<optgroup label="Mod. de base">
-                								<option value="@{FOR}">FOR</option>
-                								<option value="@{DEX}">DEX</option>
-                								<option value="@{CON}">CON</option>
-                								<option value="@{INT}">INT</option>
-                								<option value="@{PER}">PER</option>
-                								<option value="@{CHA}">CHA</option>
-                							</optgroup>
-            								<optgroup label="Mod. de test">
-                								<option value="@{FOR_TEST}" selected>FOR</option>
-                								<option value="@{DEX_TEST}">DEX</option>
-                								<option value="@{CON_TEST}">CON</option>
-                								<option value="@{INT_TEST}">INT</option>
-                								<option value="@{PER_TEST}">PER</option>
-                								<option value="@{CHA_TEST}">CHA</option>
-                							</optgroup>
-            							</select>+<input type="number" style="width:32px;" name="attr_armedmdiv" value="0" title="@{armedmdiv} Bonus de dommage divers" />
-            						</td>
-                					<td class="sheet-boxinputleft" style="width:100%;">
-                						<textarea name="attr_armespec" title="@{armespec}" placeholder="Notes, capacités spéciales, effet ..." title="@{armespec} Notes, capacités spéciales, effet ..."></textarea>
-                					</td>
-            					</tr>
-                            </table>
-                        </div>
-                        <div class="options">
-                            <table class="sheet-tabsep">
-                                <tr>
-            						<td style="width: 18px;">&nbsp;</td>
-            						<td class="sheet-boxinputleft" style="width: 130px;">
-            							<input type="text" name="attr_armejetn" style="font-weight: bold;" placeholder="Nom de l'attaque" title="@{armejetn}" />
-            						</td>
-            						<td class="sheet-boxinputleft" style="width: 145px;">&nbsp;Type de jet
-            							<select class="sheet-carac" style="width: 65px;" name="attr_armejetd" size="1" title="@{armejetd} Jet d'attaque : 'Risque' = avec d12, 'Expert' = meilleur de deux d20">
-            								<option value="1d20" selected>Normal</option>
-            								<option value="1d12">Risque (d12)</option>
-            								<option value="2d20kh1">Expert (2 d20)</option>
-            							</select>
-            						</td>
-            						<td class="sheet-boxinputleft" style="width: 32px;">
-            							<input type="number" style="width: 32px;" name="attr_armeinct" min="1" max="19" value="1" title="@{armeinct} Seuil d'incident de tir (par défaut 1)" />
-            						</td>
-            						<td class="sheet-boxinputleft">
-            						    <input type="text" name="attr_armecan" placeholder="[[@{Nom du canonnier|DEX}]][DEX canonnier] +Bonus/Rang[Armes lourdes]" title="@{armecan} Canonnier (CAN)" />
-            						</td>
-            					</tr>
-                            </table>
-                        </div>
-                    </div>
-                </fieldset>
-    		</div> 
-    	</div>
-    	<img class="sheet-imghr" src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/ChroniquesGalactiques/cog_hr.png" />
-    </div>
-    <div class="sheet-tab-content sheet-tab4">
-        <div class="sheet-row"> <!-- Config -->
-            <table class="sheet-tabsep">
-                <tr>
-                    <td style="width: 15%;">
-                        <span class="textbase">Jets</span>&nbsp;
-                        <select class="sheet-carac" style="width: 75px;" name="attr_togm" title="@{togm}" size="1">
-                            <option value="" selected>Normaux</option>
-                            <option value="/w gm ">Cachés</option>
-                        </select>
-                    </td>
-                    <td style="width: 20%;">
-                        <span class="textbase">Initiative variable</span>&nbsp;<input type="checkbox" name="attr_INIT_VAR" title="@{INIT_VAR}" value="[[1d6!]]" />
-                    </td>
-                    <td style="width: 25%;"></td>
-                    <td style="width: 20%;"></td>
-                    <td style="width: 20%;"></td>
-                </tr>
-            </table>
-        </div> <!-- FIN Config -->
-        <img class="sheet-imghr" src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/ChroniquesGalactiques/cog_hr.png" />
-        <div class="sheet-row"> <!-- BUFFS -->
-            <div class="sheet-textfatleft">BUFFS</div>
-            <table class="sheet-tabsep">
-                <tr>
-                    <td style="width: 5%;">FOR:</td>
-                    <td style="width: 19%;">
-                        <input class="sheet-buff" style="width: 70%;" type="text" name="attr_FOR_BUFF1_DESC" /><input class="sheet-buff" type="number" name="attr_FOR_BUFF1" />
-                    </td>
-                    <td style="width: 19%;">
-                        <input class="sheet-buff" style="width: 70%;" type="text" name="attr_FOR_BUFF2_DESC" /><input class="sheet-buff" type="number" name="attr_FOR_BUFF2" />
-                    </td>
-                    <td style="width: 19%;">
-                        <input class="sheet-buff" style="width: 70%;" type="text" name="attr_FOR_BUFF3_DESC" /><input class="sheet-buff" type="number" name="attr_FOR_BUFF3" />
-                    </td>
-                    <td style="width: 19%;">
-                        <input class="sheet-buff" style="width: 70%;" type="text" name="attr_FOR_BUFF4_DESC" /><input class="sheet-buff" type="number" name="attr_FOR_BUFF4" />
-                    </td>
-                    <td style="width: 19%;">
-                        <input class="sheet-buff" style="width: 70%;" type="text" name="attr_FOR_BUFF5_DESC" /><input class="sheet-buff" type="number" name="attr_FOR_BUFF5" />
-                    </td>
-                </tr>
-                <tr>
-                    <td style="width: 5%;">DEX:</td>
-                    <td style="width: 19%;">
-                        <input class="sheet-buff" style="width: 70%;" type="text" name="attr_DEX_BUFF1_DESC" /><input class="sheet-buff" type="number" name="attr_DEX_BUFF1" />
-                    </td>
-                    <td style="width: 19%;">
-                        <input class="sheet-buff" style="width: 70%;" type="text" name="attr_DEX_BUFF2_DESC" /><input class="sheet-buff" type="number" name="attr_DEX_BUFF2" />
-                    </td>
-                    <td style="width: 19%;">
-                        <input class="sheet-buff" style="width: 70%;" type="text" name="attr_DEX_BUFF3_DESC" /><input class="sheet-buff" type="number" name="attr_DEX_BUFF3" />
-                    </td>
-                    <td style="width: 19%;">
-                        <input class="sheet-buff" style="width: 70%;" type="text" name="attr_DEX_BUFF4_DESC" /><input class="sheet-buff" type="number" name="attr_DEX_BUFF4" />
-                    </td>
-                    <td style="width: 19%;">
-                        <input class="sheet-buff" style="width: 70%;" type="text" name="attr_DEX_BUFF5_DESC" /><input class="sheet-buff" type="number" name="attr_DEX_BUFF5" />
-                    </td>
-                </tr>
-                <tr>
-                    <td style="width: 5%;">CON:</td>
-                    <td style="width: 19%;">
-                        <input class="sheet-buff" style="width: 70%;" type="text" name="attr_CON_BUFF1_DESC" /><input class="sheet-buff" type="number" name="attr_CON_BUFF1" />
-                    </td>
-                    <td style="width: 19%;">
-                        <input class="sheet-buff" style="width: 70%;" type="text" name="attr_CON_BUFF2_DESC" /><input class="sheet-buff" type="number" name="attr_CON_BUFF2" />
-                    </td>
-                    <td style="width: 19%;">
-                        <input class="sheet-buff" style="width: 70%;" type="text" name="attr_CON_BUFF3_DESC" /><input class="sheet-buff" type="number" name="attr_CON_BUFF3" />
-                    </td>
-                    <td style="width: 19%;">
-                        <input class="sheet-buff" style="width: 70%;" type="text" name="attr_CON_BUFF4_DESC" /><input class="sheet-buff" type="number" name="attr_CON_BUFF4" />
-                    </td>
-                    <td style="width: 19%;">
-                        <input class="sheet-buff" style="width: 70%;" type="text" name="attr_CON_BUFF5_DESC" /><input class="sheet-buff" type="number" name="attr_CON_BUFF5" />
-                    </td>
-                </tr>
-                <tr>
-                    <td style="width: 5%;">INT:</td>
-                    <td style="width: 19%;">
-                        <input class="sheet-buff" style="width: 70%;" type="text" name="attr_INT_BUFF1_DESC" /><input class="sheet-buff" type="number" name="attr_INT_BUFF1" />
-                    </td>
-                    <td style="width: 19%;">
-                        <input class="sheet-buff" style="width: 70%;" type="text" name="attr_INT_BUFF2_DESC" /><input class="sheet-buff" type="number" name="attr_INT_BUFF2" />
-                    </td>
-                    <td style="width: 19%;">
-                        <input class="sheet-buff" style="width: 70%;" type="text" name="attr_INT_BUFF3_DESC" /><input class="sheet-buff" type="number" name="attr_INT_BUFF3" />
-                    </td>
-                    <td style="width: 19%;">
-                        <input class="sheet-buff" style="width: 70%;" type="text" name="attr_INT_BUFF4_DESC" /><input class="sheet-buff" type="number" name="attr_INT_BUFF4" />
-                    </td>
-                    <td style="width: 19%;">
-                        <input class="sheet-buff" style="width: 70%;" type="text" name="attr_INT_BUFF5_DESC" /><input class="sheet-buff" type="number" name="attr_INT_BUFF5" />
-                    </td>
-                </tr>
-                <tr>
-                    <td style="width: 5%;">PER:</td>
-                    <td style="width: 19%;">
-                        <input class="sheet-buff" style="width: 70%;" type="text" name="attr_PER_BUFF1_DESC" /><input class="sheet-buff" type="number" name="attr_PER_BUFF1" />
-                    </td>
-                    <td style="width: 19%;">
-                        <input class="sheet-buff" style="width: 70%;" type="text" name="attr_PER_BUFF2_DESC" /><input class="sheet-buff" type="number" name="attr_PER_BUFF2" />
-                    </td>
-                    <td style="width: 19%;">
-                        <input class="sheet-buff" style="width: 70%;" type="text" name="attr_PER_BUFF3_DESC" /><input class="sheet-buff" type="number" name="attr_PER_BUFF3" />
-                    </td>
-                    <td style="width: 19%;">
-                        <input class="sheet-buff" style="width: 70%;" type="text" name="attr_PER_BUFF4_DESC" /><input class="sheet-buff" type="number" name="attr_PER_BUFF4" />
-                    </td>
-                    <td style="width: 19%;">
-                        <input class="sheet-buff" style="width: 70%;" type="text" name="attr_PER_BUFF5_DESC" /><input class="sheet-buff" type="number" name="attr_PER_BUFF5" />
-                    </td>
-                </tr>
-                <tr>
-                    <td style="width: 5%;">CHA:</td>
-                    <td style="width: 19%;">
-                        <input class="sheet-buff" style="width: 70%;" type="text" name="attr_CHA_BUFF1_DESC" /><input class="sheet-buff" type="number" name="attr_CHA_BUFF1" />
-                    </td>
-                    <td style="width: 19%;">
-                        <input class="sheet-buff" style="width: 70%;" type="text" name="attr_CHA_BUFF2_DESC" /><input class="sheet-buff" type="number" name="attr_CHA_BUFF2" />
-                    </td>
-                    <td style="width: 19%;">
-                        <input class="sheet-buff" style="width: 70%;" type="text" name="attr_CHA_BUFF3_DESC" /><input class="sheet-buff" type="number" name="attr_CHA_BUFF3" />
-                    </td>
-                    <td style="width: 19%;">
-                        <input class="sheet-buff" style="width: 70%;" type="text" name="attr_CHA_BUFF4_DESC" /><input class="sheet-buff" type="number" name="attr_CHA_BUFF4" />
-                    </td>
-                    <td style="width: 19%;">
-                        <input class="sheet-buff" style="width: 70%;" type="text" name="attr_CHA_BUFF5_DESC" /><input class="sheet-buff" type="number" name="attr_CHA_BUFF5" />
-                    </td>
-                </tr>
-                <tr>
-                    <td style="width: 5%;">ATC:</td>
-                    <td style="width: 19%;">
-                        <input class="sheet-buff" style="width: 70%;" type="text" name="attr_ATKCAC_BUFF1_DESC" /><input class="sheet-buff" type="number" name="attr_ATKCAC_BUFF1" />
-                    </td>
-                    <td style="width: 19%;">
-                        <input class="sheet-buff" style="width: 70%;" type="text" name="attr_ATKCAC_BUFF2_DESC" /><input class="sheet-buff" type="number" name="attr_ATKCAC_BUFF2" />
-                    </td>
-                    <td style="width: 19%;">
-                        <input class="sheet-buff" style="width: 70%;" type="text" name="attr_ATKCAC_BUFF3_DESC" /><input class="sheet-buff" type="number" name="attr_ATKCAC_BUFF3" />
-                    </td>
-                    <td style="width: 19%;">
-                        <input class="sheet-buff" style="width: 70%;" type="text" name="attr_ATKCAC_BUFF4_DESC" /><input class="sheet-buff" type="number" name="attr_ATKCAC_BUFF4" />
-                    </td>
-                    <td style="width: 19%;">
-                        <input class="sheet-buff" style="width: 70%;" type="text" name="attr_ATKCAC_BUFF5_DESC" /><input class="sheet-buff" type="number" name="attr_ATKCAC_BUFF5" />
-                    </td>
-                </tr>
-                <tr>
-                    <td style="width: 5%;">ATD:</td>
-                    <td style="width: 19%;">
-                        <input class="sheet-buff" style="width: 70%;" type="text" name="attr_ATKTIR_BUFF1_DESC" /><input class="sheet-buff" type="number" name="attr_ATKTIR_BUFF1" />
-                    </td>
-                    <td style="width: 19%;">
-                        <input class="sheet-buff" style="width: 70%;" type="text" name="attr_ATKTIR_BUFF2_DESC" /><input class="sheet-buff" type="number" name="attr_ATKTIR_BUFF2" />
-                    </td>
-                    <td style="width: 19%;">
-                        <input class="sheet-buff" style="width: 70%;" type="text" name="attr_ATKTIR_BUFF3_DESC" /><input class="sheet-buff" type="number" name="attr_ATKTIR_BUFF3" />
-                    </td>
-                    <td style="width: 19%;">
-                        <input class="sheet-buff" style="width: 70%;" type="text" name="attr_ATKTIR_BUFF4_DESC" /><input class="sheet-buff" type="number" name="attr_ATKTIR_BUFF4" />
-                    </td>
-                    <td style="width: 19%;">
-                        <input class="sheet-buff" style="width: 70%;" type="text" name="attr_ATKTIR_BUFF5_DESC" /><input class="sheet-buff" type="number" name="attr_ATKTIR_BUFF5" />
-                    </td>
-                </tr>
-                <tr>
-                    <td style="width: 5%;">MAG:</td>
-                    <td style="width: 19%;">
-                        <input class="sheet-buff" style="width: 70%;" type="text" name="attr_ATKMAG_BUFF1_DESC" /><input class="sheet-buff" type="number" name="attr_ATKMAG_BUFF1" />
-                    </td>
-                    <td style="width: 19%;">
-                        <input class="sheet-buff" style="width: 70%;" type="text" name="attr_ATKMAG_BUFF2_DESC" /><input class="sheet-buff" type="number" name="attr_ATKMAG_BUFF2" />
-                    </td>
-                    <td style="width: 19%;">
-                        <input class="sheet-buff" style="width: 70%;" type="text" name="attr_ATKMAG_BUFF3_DESC" /><input class="sheet-buff" type="number" name="attr_ATKMAG_BUFF3" />
-                    </td>
-                    <td style="width: 19%;">
-                        <input class="sheet-buff" style="width: 70%;" type="text" name="attr_ATKMAG_BUFF4_DESC" /><input class="sheet-buff" type="number" name="attr_ATKMAG_BUFF4" />
-                    </td>
-                    <td style="width: 19%;">
-                        <input class="sheet-buff" style="width: 70%;" type="text" name="attr_ATKMAG_BUFF5_DESC" /><input class="sheet-buff" type="number" name="attr_ATKMAG_BUFF5" />
-                    </td>
-                </tr>
-                <tr>
-                    <td style="width: 5%;">MEN:</td>
-                    <td style="width: 19%;">
-                        <input class="sheet-buff" style="width: 70%;" type="text" name="attr_ATKMEN_BUFF1_DESC" /><input class="sheet-buff" type="number" name="attr_ATKMEN_BUFF1" />
-                    </td>
-                    <td style="width: 19%;">
-                        <input class="sheet-buff" style="width: 70%;" type="text" name="attr_ATKMEN_BUFF2_DESC" /><input class="sheet-buff" type="number" name="attr_ATKMEN_BUFF2" />
-                    </td>
-                    <td style="width: 19%;">
-                        <input class="sheet-buff" style="width: 70%;" type="text" name="attr_ATKMEN_BUFF3_DESC" /><input class="sheet-buff" type="number" name="attr_ATKMEN_BUFF3" />
-                    </td>
-                    <td style="width: 19%;">
-                        <input class="sheet-buff" style="width: 70%;" type="text" name="attr_ATKMEN_BUFF4_DESC" /><input class="sheet-buff" type="number" name="attr_ATKMEN_BUFF4" />
-                    </td>
-                    <td style="width: 19%;">
-                        <input class="sheet-buff" style="width: 70%;" type="text" name="attr_ATKMEN_BUFF5_DESC" /><input class="sheet-buff" type="number" name="attr_ATKMEN_BUFF5" />
-                    </td>
-                </tr>
-                <tr>
-                    <td style="width: 5%;">INIT:</td>
-                    <td style="width: 19%;">
-                        <input class="sheet-buff" style="width: 70%;" type="text" name="attr_INIT_BUFF1_DESC" /><input class="sheet-buff" type="number" name="attr_INIT_BUFF1" />
-                    </td>
-                    <td style="width: 19%;">
-                        <input class="sheet-buff" style="width: 70%;" type="text" name="attr_INIT_BUFF2_DESC" /><input class="sheet-buff" type="number" name="attr_INIT_BUFF2" />
-                    </td>
-                    <td style="width: 19%;">
-                        <input class="sheet-buff" style="width: 70%;" type="text" name="attr_INIT_BUFF3_DESC" /><input class="sheet-buff" type="number" name="attr_INIT_BUFF3" />
-                    </td>
-                    <td style="width: 19%;">
-                        <input class="sheet-buff" style="width: 70%;" type="text" name="attr_INIT_BUFF4_DESC" /><input class="sheet-buff" type="number" name="attr_INIT_BUFF4" />
-                    </td>
-                    <td style="width: 19%;">
-                        <input class="sheet-buff" style="width: 70%;" type="text" name="attr_INIT_BUFF5_DESC" /><input class="sheet-buff" type="number" name="attr_INIT_BUFF5" />
-                    </td>
-                </tr>
-                <tr>
-                    <td style="width: 5%;">DEF:</td>
-                    <td style="width: 19%;">
-                        <input class="sheet-buff" style="width: 70%;" type="text" name="attr_DEF_BUFF1_DESC" /><input class="sheet-buff" type="number" name="attr_DEF_BUFF1" />
-                    </td>
-                    <td style="width: 19%;">
-                        <input class="sheet-buff" style="width: 70%;" type="text" name="attr_DEF_BUFF2_DESC" /><input class="sheet-buff" type="number" name="attr_DEF_BUFF2" />
-                    </td>
-                    <td style="width: 19%;">
-                        <input class="sheet-buff" style="width: 70%;" type="text" name="attr_DEF_BUFF3_DESC" /><input class="sheet-buff" type="number" name="attr_DEF_BUFF3" />
-                    </td>
-                    <td style="width: 19%;">
-                        <input class="sheet-buff" style="width: 70%;" type="text" name="attr_DEF_BUFF4_DESC" /><input class="sheet-buff" type="number" name="attr_DEF_BUFF4" />
-                    </td>
-                    <td style="width: 19%;">
-                        <input class="sheet-buff" style="width: 70%;" type="text" name="attr_DEF_BUFF5_DESC" /><input class="sheet-buff" type="number" name="attr_DEF_BUFF5" />
-                    </td>
-                </tr>
-            </table>
-            <div>
-                <input type="checkbox" class="sheet-block-switch" name="attr_voir_psy" title="@{voir_psy}" value="1"><span>Afficher les attributs PSY</span>
-                <div class="sheet-block-hidden"></div>
-                <div class="sheet-block-show">
-                    <table>
-                        <tr>
-                            <td style="width: 5%;">PSYInf.:</td>
-                            <td style="width: 19%;">
-                                <input class="sheet-buff" style="width: 70%;" type="text" name="attr_PSYINFLU_BUFF1_DESC" /><input class="sheet-buff" type="number" name="attr_PSYINFLU_BUFF1" />
-                            </td>
-                            <td style="width: 19%;">
-                                <input class="sheet-buff" style="width: 70%;" type="text" name="attr_PSYINFLU_BUFF2_DESC" /><input class="sheet-buff" type="number" name="attr_PSYINFLU_BUFF2" />
-                            </td>
-                            <td style="width: 19%;">
-                                <input class="sheet-buff" style="width: 70%;" type="text" name="attr_PSYINFLU_BUFF3_DESC" /><input class="sheet-buff" type="number" name="attr_PSYINFLU_BUFF3" />
-                            </td>
-                            <td style="width: 19%;">
-                                <input class="sheet-buff" style="width: 70%;" type="text" name="attr_PSYINFLU_BUFF4_DESC" /><input class="sheet-buff" type="number" name="attr_PSYINFLU_BUFF4" />
-                            </td>
-                            <td style="width: 19%;">
-                                <input class="sheet-buff" style="width: 70%;" type="text" name="attr_PSYINFLU_BUFF5_DESC" /><input class="sheet-buff" type="number" name="attr_PSYINFLU_BUFF5" />
-                            </td>
-                        </tr>
-                        <tr>
-                            <td style="width: 5%;">PSYInt.:</td>
-                            <td style="width: 19%;">
-                                <input class="sheet-buff" style="width: 70%;" type="text" name="attr_PSYINTUI_BUFF1_DESC" /><input class="sheet-buff" type="number" name="attr_PSYINTUI_BUFF1" />
-                            </td>
-                            <td style="width: 19%;">
-                                <input class="sheet-buff" style="width: 70%;" type="text" name="attr_PSYINTUI_BUFF2_DESC" /><input class="sheet-buff" type="number" name="attr_PSYINTUI_BUFF2" />
-                            </td>
-                            <td style="width: 19%;">
-                                <input class="sheet-buff" style="width: 70%;" type="text" name="attr_PSYINTUI_BUFF3_DESC" /><input class="sheet-buff" type="number" name="attr_PSYINTUI_BUFF3" />
-                            </td>
-                            <td style="width: 19%;">
-                                <input class="sheet-buff" style="width: 70%;" type="text" name="attr_PSYINTUI_BUFF4_DESC" /><input class="sheet-buff" type="number" name="attr_PSYINTUI_BUFF4" />
-                            </td>
-                            <td style="width: 19%;">
-                                <input class="sheet-buff" style="width: 70%;" type="text" name="attr_PSYINTUI_BUFF5_DESC" /><input class="sheet-buff" type="number" name="attr_PSYINTUI_BUFF5" />
-                            </td>
-                        </tr>
-                        <tr>
-                            <td style="width: 5%;">DEFPsy:</td>
-                            <td style="width: 19%;">
-                                <input class="sheet-buff" style="width: 70%;" type="text" name="attr_DEP_BUFF1_DESC" /><input class="sheet-buff" type="number" name="attr_DEP_BUFF1" />
-                            </td>
-                            <td style="width: 19%;">
-                                <input class="sheet-buff" style="width: 70%;" type="text" name="attr_DEP_BUFF2_DESC" /><input class="sheet-buff" type="number" name="attr_DEP_BUFF2" />
-                            </td>
-                            <td style="width: 19%;">
-                                <input class="sheet-buff" style="width: 70%;" type="text" name="attr_DEP_BUFF3_DESC" /><input class="sheet-buff" type="number" name="attr_DEP_BUFF3" />
-                            </td>
-                            <td style="width: 19%;">
-                                <input class="sheet-buff" style="width: 70%;" type="text" name="attr_DEP_BUFF4_DESC" /><input class="sheet-buff" type="number" name="attr_DEP_BUFF4" />
-                            </td>
-                            <td style="width: 19%;">
-                                <input class="sheet-buff" style="width: 70%;" type="text" name="attr_DEP_BUFF5_DESC" /><input class="sheet-buff" type="number" name="attr_DEP_BUFF5" />
-                            </td>
-                        </tr>
-                    </table>
-                </div>
-            </div>
-            <div>
-                <input type="checkbox" class="sheet-block-switch" name="attr_voir_vdef" title="@{voir_vdef}" value="1"><span>Afficher les bonus de vaisseau</span>
-                <div class="sheet-block-hidden"></div>
-                <div class="sheet-block-show">
-                    <table>
-                        <tr>
-                            <td style="width: 5%;">ATD:</td>
-                            <td style="width: 19%;">
-                                <input class="sheet-buff" style="width: 70%;" type="text" name="attr_ATKTIRV_BUFF1_DESC" /><input class="sheet-buff" type="number" name="attr_ATKTIRV_BUFF1" />
-                            </td>
-                            <td style="width: 19%;">
-                                <input class="sheet-buff" style="width: 70%;" type="text" name="attr_ATKTIRV_BUFF2_DESC" /><input class="sheet-buff" type="number" name="attr_ATKTIRV_BUFF2" />
-                            </td>
-                            <td style="width: 19%;">
-                                <input class="sheet-buff" style="width: 70%;" type="text" name="attr_ATKTIRV_BUFF3_DESC" /><input class="sheet-buff" type="number" name="attr_ATKTIRV_BUFF3" />
-                            </td>
-                            <td style="width: 19%;">
-                                <input class="sheet-buff" style="width: 70%;" type="text" name="attr_ATKTIRV_BUFF4_DESC" /><input class="sheet-buff" type="number" name="attr_ATKTIRV_BUFF4" />
-                            </td>
-                            <td style="width: 19%;">
-                                <input class="sheet-buff" style="width: 70%;" type="text" name="attr_ATKTIRV_BUFF5_DESC" /><input class="sheet-buff" type="number" name="attr_ATKTIRV_BUFF5" />
-                            </td>
-                        </tr>
-                        <tr>
-                            <td style="width: 5%;">PIL:</td>
-                            <td style="width: 19%;">
-                                <input class="sheet-buff" style="width: 70%;" type="text" name="attr_DEFVPIL_BUFF1_DESC" /><input class="sheet-buff" type="number" name="attr_DEFVPIL_BUFF1" />
-                            </td>
-                            <td style="width: 19%;">
-                                <input class="sheet-buff" style="width: 70%;" type="text" name="attr_DEFVPIL_BUFF2_DESC" /><input class="sheet-buff" type="number" name="attr_DEFVPIL_BUFF2" />
-                            </td>
-                            <td style="width: 19%;">
-                                <input class="sheet-buff" style="width: 70%;" type="text" name="attr_DEFVPIL_BUFF3_DESC" /><input class="sheet-buff" type="number" name="attr_DEFVPIL_BUFF3" />
-                            </td>
-                            <td style="width: 19%;">
-                                <input class="sheet-buff" style="width: 70%;" type="text" name="attr_DEFVPIL_BUFF4_DESC" /><input class="sheet-buff" type="number" name="attr_DEFVPIL_BUFF4" />
-                            </td>
-                            <td style="width: 19%;">
-                                <input class="sheet-buff" style="width: 70%;" type="text" name="attr_DEFVPIL_BUFF5_DESC" /><input class="sheet-buff" type="number" name="attr_DEFVPIL_BUFF5" />
-                            </td>
-                        </tr>
-                        <tr>
-                            <td style="width: 5%;">SEN:</td>
-                            <td style="width: 19%;">
-                                <input class="sheet-buff" style="width: 70%;" type="text" name="attr_DEFVSEN_BUFF1_DESC" /><input class="sheet-buff" type="number" name="attr_DEFVSEN_BUFF1" />
-                            </td>
-                            <td style="width: 19%;">
-                                <input class="sheet-buff" style="width: 70%;" type="text" name="attr_DEFVSEN_BUFF2_DESC" /><input class="sheet-buff" type="number" name="attr_DEFVSEN_BUFF2" />
-                            </td>
-                            <td style="width: 19%;">
-                                <input class="sheet-buff" style="width: 70%;" type="text" name="attr_DEFVSEN_BUFF3_DESC" /><input class="sheet-buff" type="number" name="attr_DEFVSEN_BUFF3" />
-                            </td>
-                            <td style="width: 19%;">
-                                <input class="sheet-buff" style="width: 70%;" type="text" name="attr_DEFVSEN_BUFF4_DESC" /><input class="sheet-buff" type="number" name="attr_DEFVSEN_BUFF4" />
-                            </td>
-                            <td style="width: 19%;">
-                                <input class="sheet-buff" style="width: 70%;" type="text" name="attr_DEFVSEN_BUFF5_DESC" /><input class="sheet-buff" type="number" name="attr_DEFVSEN_BUFF5" />
-                            </td>
-                        </tr>
-                        <tr>
-                            <td style="width: 5%;">PE:</td>
-                            <td style="width: 19%;">
-                                <input class="sheet-buff" style="width: 70%;" type="text" name="attr_PEV_BUFF1_DESC" /><input class="sheet-buff" type="number" name="attr_PEV_BUFF1" />
-                            </td>
-                            <td style="width: 19%;">
-                                <input class="sheet-buff" style="width: 70%;" type="text" name="attr_PEV_BUFF2_DESC" /><input class="sheet-buff" type="number" name="attr_PEV_BUFF2" />
-                            </td>
-                            <td style="width: 19%;">
-                                <input class="sheet-buff" style="width: 70%;" type="text" name="attr_PEV_BUFF3_DESC" /><input class="sheet-buff" type="number" name="attr_PEV_BUFF3" />
-                            </td>
-                            <td style="width: 19%;">
-                                <input class="sheet-buff" style="width: 70%;" type="text" name="attr_PEV_BUFF4_DESC" /><input class="sheet-buff" type="number" name="attr_PEV_BUFF4" />
-                            </td>
-                            <td style="width: 19%;">
-                                <input class="sheet-buff" style="width: 70%;" type="text" name="attr_PEV_BUFF5_DESC" /><input class="sheet-buff" type="number" name="attr_PEV_BUFF5" />
-                            </td>
-                        </tr>
-                    </table>
-                </div>
-            </div>
-        </div> <!-- FIN BUFFS -->
-        <img class="sheet-imghr" src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/ChroniquesGalactiques/cog_hr.png" />
-    </div>
+		        </div>
+		    </div>
+		</div>
+	</div>
 </div> <!-- FIN FDP -->
 <!-- TEMPLATES -->
 <rolltemplate class="sheet-rolltemplate-co1">

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,1 +1,1 @@
-theme: jekyll-theme-modernist
+theme: jekyll-theme-slate

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,1 @@
+theme: jekyll-theme-modernist

--- a/docs/import-statblock.md
+++ b/docs/import-statblock.md
@@ -1,0 +1,43 @@
+# Import de statblock #
+
+La version 3.3 de la fiche de personnage Chroniques Galactiques comporte une fonction d'import de statblock (bloc d'attributs abrégé résumant les données techniques de jeu) pour les fiches de PNJ. Cette fonction tente d'extraire les données du statblock et les insère dans la fiche de PNJ.
+
+Cette fonction est capable de récupérer :
+* Le Niveau de Créature (NC)
+* Le type de créature, inséré dans le champ Profil
+* La taille de la créature (de "très petite" à "colossale")
+* Les six caractéristiques principales (FOR, DEX, CON, INT, SAG/PER, CHA)
+* Les attributs de combat (PV, DEF et Init)
+* Les diverses lignes d'attaque
+
+## Mode d'emploi ##
+Pour importer un statblock et récupérer ses données dans une fiche de PNJ :
+1. Copier le texte du statblock depuis un document PDF
+2. Sur l'onglet _PNJ_ et le sous-onglet _Configuration_, cliquer sur la flèche _Importer statblock_ pour afficher le champ d'import
+3. Coller le texte précédemment copié dans le champ approprié
+4. Cliquer en dehors de ce champ : la fonction d'import se déclenche
+
+Si l'import se déroule sans encombres, le champ contenant le statblock est effacé.
+
+Si un problème se pose au cours de l'import et que la fonction n'est capable d'extraire qu'une partie des données du PNJ, un ou plusieurs messages explicitant l'origine du problème sont affichés dans le champ texte résultat.
+
+Si le champ contenant le statblock n'est pas effacé, il s'agit d'une erreur d'analyse ayant entraîné l'arrêt de l'import.
+
+## Format du statblock ##
+
+_NC xxx, créature xxx, taille xxx_                                                                         
+_FOR xxx DEX xxx CON xxx_                                                                                
+_INT xxx PER xxx CHA xxx_                                                                                        
+_DEF xxx PV xxx (RD xxx) Init xxx_                                                                               
+_Attaque/Arme (autres info) +Bonus DM Dommages (autres infos)_                                             
+_Autre attaque DM Dommages (autres infos)_                                             
+
+Toutes les données n'ont pas obligatoirement à être présentes. La fonction d'import extrait celles qu'elle trouve et les insère dans les champs appropriés de la fiche de PNJ, les autres seront à remplir manuellement.
+
+## Trucs & astuces ##
+* Lorsque le statblock est collé dans le champ d'import, prenez soin de supprimer les sauts de lignes surnuméraires, qui surviennent souvent sur la première ligne du bloc ou sur les lignes d'attaques
+* Une ligne d'attaque est reconnue comme telle si elle comporte le mot DM.
+* Le bonus d'attaque est le premier chiffre précédé d'un signe + présent sur la ligne d'attaque
+* Les dommages sont le premier mot de la ligne d'attaque après le mot DM
+* La fonction d'import regroupe les autres infos de la ligne d'attaque dans un champ _Spécial_ et si elle y détecte la mention d'un jet de dés, elle remet celui-ci en forme de manière à effectuer un _"inline roll"_ lorsque l'attaque est utilisée.
+* Toutes les données extraites du statblock qui ne correspondent pas à un champ sur la fiche de PNJ sont regroupées dans le champ texte _Capacités_

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,3 @@
 Index des documents Chroniques Galactiques
 
-[Import de statblock]({{ site.baseurl }}/docs/import-statblock.md)
+[Import de statblock]({{ site.baseurl }}/docs/import-statblock)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,1 +1,3 @@
 Index des documents Chroniques Galactiques
+
+[Import de statblock]({{ site.baseurl }}/docs/import-statblock.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,5 @@
-Index des documents Chroniques Galactiques
+## Documents pour la fiche de personnage Chroniques Galactiques ##
+
+Cliquer sur un lien pour consulter la documentation correspondante :
 
 [Import de statblock]({{ site.baseurl }}/import-statblock)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,3 @@
 Index des documents Chroniques Galactiques
 
-[Import de statblock]({{ site.baseurl }}/docs/import-statblock)
+[Import de statblock]({{ site.baseurl }}/import-statblock)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,1 @@
+Index des documents Chroniques Galactiques


### PR DESCRIPTION
@Ulty : Fiche de personnage CG Version 3.3

- Réorganisation en 3 onglets principaux (Personnage, Vaisseau, PNJ) avec des sous-onglets 
- Chargement automatiques des intitulés de buffs par défaut pour les vaisseaux (fait une fois et une seule à la première ouverture de la fiche)
- Fonction d'import du statblock dans la fiche de PNJ. A priori tu peux reprendre le code tel quel, si tu prends soin de rajouter dans la fiche de perso COF un champ hidden UNIVERS auquel tu assignes la valeur COF. Le code s'occupera tout seul de faire la correspondance SAG <=> PER (en le signalant à la fin de l'import). Ce qui te permet, pourquoi pas, d'importer un monstre du bestiaire COF dans un PNJ COC (ou CG).
- J'ai créé des docs hébergés sur Github : un document expliquant l'import de statblock et une page d'accueil : https://stephaned68.github.io/ChroniquesGalactiques/ 
