### PR TITLE
MAJ Fiche CG V3.8

### DIFF
--- a/cog.htm
+++ b/cog.htm
@@ -1316,12 +1316,13 @@
               <table class="sheet-tabsep">
                 <tr>
                   <td>
-                    <button type="roll" class="sheet-neutre" name="roll_vatk" title="%{repeating_armesv_$N_vatk}" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{subtags=Tir}} {{name=@{armenom}}} {{desc=@{armejetn}@{armecan_nom}}} {{attaque=[[@{armejetd}cs>@{armecrit}cf<@{armeinct}[Dé] + [[@{armeatk}]][Attaque] + @{armecan} + @{armeatkdiv}[Bonus] ]]}} {{degats=[[@{armedmnbde}d@{armedmde}[Dé DM] + [[@{armedmcar}]][Mod.DM] + @{armedmdiv}[Bonus DM] ]]}} {{special=@{armespec}}}" />
+                    <button type="roll" class="sheet-neutre" name="roll_vatk" title="%{repeating_armesv_$N_vatk}" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{subtags=Tir}} {{name=@{armenom}}} {{desc=@{armecan_nom}}} {{text=@{armejetn}}} {{@{armeatt}[[@{armejetd}cs>@{armecrit}cf<@{armeinct}[Dé] + [[@{armeatk}]][Attaque] + @{armecan} + @{armeatkdiv}[Bonus] ]]}} {{@{armedmg}[[@{armedmnbde}d@{armedmde}[Dé DM] + [[@{armedmcar}]][Mod.DM] + @{armedmdiv}[Bonus DM] ]]}} {{special=@{armespec}}}" />
                   </td>
                   <td class="sheet-boxinputleft" style="min-width: 140px;">
                     <input type="text" name="attr_armenom" title="@{armenom}" style="font-weight: bold;" placeholder="Arme/attaque" />
                   </td>
                   <td class="sheet-boxinputleft" style="min-width: 135px;">
+                    <input type="checkbox" name="attr_armeatt" title="@{armeatt}" value="attaque=" checked="checked" />
                     <select class="sheet-carac" style="width: 87px;" name="attr_armeatk" title="@{armeatk}" size="1">
                       <option value="@{ATKTIRV}" selected>DISTANCE</option>
                     </select>+<input type="number" style="width:32px;" name="attr_armeatkdiv" value="0" title="@{armeatkdiv} Bonus d'attaque divers" />
@@ -1330,6 +1331,7 @@
                     <input type="number" name="attr_armecrit" style="width:32px;" min="2" max="20" value="20" title="@{armecrit} Seuil de Critique (par défaut 20)" />
                   </td>
                   <td class="sheet-boxinputleft">
+                    <input type="checkbox" name="attr_armedmg" title="@{armedmg}" value="degats=" checked="checked" />
                     <input type="number" style="width:32px;" name="attr_armedmnbde" value="1" title="@{armedmnbde} Nombre de dés de dommage" />
                     <select class="sheet-carac" style="width:47px;" name="attr_armedmde" size="1" title="@{armedmde} Dé de dommage">
                       <option value="4">d4</option>
@@ -1368,7 +1370,7 @@
                 <tr>
                   <td style="width: 18px;">&nbsp;</td>
                   <td class="sheet-boxinputleft" style="width: 272px;">
-                    <input type="text" name="attr_armejetn" style="width: 242px; font-weight: bold;" placeholder="Nom de l'attaque" title="@{armejetn}" />
+                    <input type="text" name="attr_armejetn" style="width: 255px; font-weight: bold;" placeholder="Nom de l'attaque" title="@{armejetn}" />
                     <select class="sheet-carac" style="width: 30px;" name="attr_armejetd" size="1" title="@{armejetd} Jet d'attaque : 'Risque' = avec d12, 'Expert' = meilleur de deux d20">
                       <option value="1d20" selected>Normal</option>
                       <option value="1d12">Risque (d12)</option>

--- a/cog.htm
+++ b/cog.htm
@@ -1,8 +1,8 @@
 <div class="sheet-mainBg">
   <!-- FDP -->
   <!-- INPUT HIDDEN Version FdP -->
-  <input type="hidden" name="attr_verfdp" value="3.7" />
-  <input type="hidden" name="attr_VERSION" value="3.7" />
+  <input type="hidden" name="attr_verfdp" value="3.8" />
+  <input type="hidden" name="attr_VERSION" value="3.8" />
   <!-- INPUT HIDDEN Univers (COF, CG, COC) -->
   <input type="hidden" name="attr_UNIVERS" value="CG" />
   <!-- INPUT HIDDEN Type de jets -->
@@ -31,6 +31,7 @@
   <input type="hidden" name="attr_INIT_BUFF" value="0" />
   <input type="hidden" name="attr_DEF_BUFF" value="0" />
   <input type="hidden" name="attr_DEP_BUFF" value="0" />
+  <input type="hidden" name="attr_PV_BUFF" value="0" />
   <!-- INPUT HIDDEN Malus Armure -->
   <input type="hidden" name="attr_ARMURE_MALUS" value="0" />
   <!-- INPUT HIDDEN Buffs vaisseau -->
@@ -65,11 +66,6 @@
   <input type="hidden" name="attr_RANG_VOIE9" value="0" />
   <!-- INPUT HIDDEN Caractéristiques -->
   <input type="hidden" name="attr_CARACS" value="" />
-  <!-- INPUT HIDDEN Mods de circonstance attaques -->
-  <input type="hidden" name="attr_MODS_ATC" value="" />
-  <input type="hidden" name="attr_MODS_ATD" value="" />
-  <input type="hidden" name="attr_MODS_MEN" value="" />
-  <input type="hidden" name="attr_MODS_MAG" value="" />
   <!-- FIN Hidden -->
   <div style="display: none;">
     <button type="roll" name="roll_incident_tir" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{subtags=Attaque}} {{name=Incident de tir}} {{test=[[1d20cf1cs>2]]}} {{test_crit=Surchauffe ! Tir au prochain tour}} {{test_fumble=Batterie déchargée !}}" />
@@ -77,7 +73,7 @@
   <div class="sheet-container">
     <!-- Identité -->
     <div style="width: 420px; vertical-align: middle; text-align: center;">
-      <img width="340" title="Version 3.7 - 21/09/2019" src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/ChroniquesGalactiques/cog_logo.png" />
+      <img width="340" title="Version 3.8 - 28/09/2019" src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/ChroniquesGalactiques/cog_logo.png" />
     </div>
     <div style="width: 250px;">
       <table>
@@ -394,7 +390,10 @@
                         <td class="sheet-textfat" colspan="2">VITALIT&Eacute;</td>
                       </tr>
                       <tr>
-                        <td class="sheet-boxtitre"><button class="sheet-boxtitre" type="roll" name="roll_jet_dv" title="%{jet_dv} Jet de D&eacute; de Vie" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{name=Dé de Vie}} {{subtags=Vitalit&eacute;}} {{DV=[[1d@{DV}[DV] + [[@{CON}]][Mod. CON] ]]}}"> DV</button></td>
+                        <td class="sheet-boxtitre">
+                          <button class="sheet-boxtitre" type="action" name="act_dv_btn" title="Progression d'un niveau">
+                            DV</button>
+                        </td>
                         <td class="sheet-boxinput">
                           <select class="sheet-carac" name="attr_DV" size="1" title="@{DV} D&eacute; de Vie">
                             <option value="0" selected>-</option>
@@ -519,7 +518,7 @@
               <table class="sheet-tabsep">
                 <tr>
                   <td>
-                    <button type="roll" class="sheet-neutre" name="roll_atk" title="%{repeating_armes_$N_atk}" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{subtags=Attaque}} {{name=@{armenom}}} {{portee=@{armeportees}}} {{desc=@{armejetn} @{armelim}}} {{@{armeatt}[[@{armejetd}cs>@{armecrit}cf<@{armeinct}[Dé] + [[@{armeatk}]][Attaque] + [[@{armeatkdiv}]][Bonus] + (@{armebuff}) ]]}} {{@{armedmg}[[[[@{armedmnbde}d@{armedmde}@{armedmrel}@{armedmvrel}]][Dé DM] + ([[@{armedmcar}]])[Mod.DM] + (@{armedmdiv})[Bonus DM] + (@{armebuffdm}) ]]}} {{dmtype=@{armedmtype}}} {{degats2=@{armedmg2}}} {{dm2type=@{armedm2_desc}}} {{special=@{armespec}}}" />
+                    <button type="roll" class="sheet-neutre" name="roll_pjatk" title="%{repeating_armes_$N_pjatk}" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{subtags=Attaque}} {{name=@{armenom}}} {{portee=@{armeportees}}} {{desc=@{armejetn} @{armelim}}} {{@{armeatt}[[@{armejetd}cs>@{armecrit}cf<@{armeinct}[Dé] + [[@{armeatk}]][Attaque] + [[@{armeatkdiv}]][Bonus] + (@{armebuff}) ]]}} {{@{armedmg}[[[[@{armedmnbde}d@{armedmde}@{armedmrel}@{armedmvrel}]][Dé DM] + ([[@{armedmcar}]])[Mod.DM] + (@{armedmdiv})[Bonus DM] + (@{armebuffdm}) ]]}} {{dmtype=@{armedmtype}}} {{degats2=@{armedmg2}}} {{dm2type=@{armedm2_desc}}} {{special=@{armespec}}}" />
                   </td>
                   <td class="sheet-boxinputleft" style="min-width: 130px;">
                     <input type="text" name="attr_armenom" title="@{armenom}" style="font-weight: bold;" placeholder="Arme/attaque" />
@@ -626,15 +625,24 @@
         </fieldset>
         <table>
           <tr>
-            <td>&nbsp;</td>
+            <td colspan="2">&nbsp;</td>
           </tr>
           <tr>
+            <td style="width: 35px; text-align: right;">Att. :</td>
             <td>
-              <textarea class="sheet-boxinputleft" style="height: 5em;" name="attr_mods_atk" title="Modificateurs de circonstances" placeholder="Ex: ATD -5 Portée double; DM ATD +[PER] Visée" value=""></textarea>
+              <textarea class="sheet-boxinputleft" style="height: 3em;" name="attr_mods_atk"
+                title="Modificateurs de circonstances" placeholder="Ex: ATD -5 Portée double" value=""></textarea>
             </td>
           </tr>
           <tr>
-            <td style="text-align: left;"><span name="attr_INFOMSG"></span></td>
+            <td style="width: 35px; text-align: right;">DM :</td>
+            <td>
+              <textarea class="sheet-boxinputleft" style="height: 3em;" name="attr_mods_atkdm"
+                title="Modificateurs de circonstances" placeholder="Ex: ATD +[PER] Visée" value=""></textarea>
+            </td>
+          </tr>
+          <tr>
+            <td colspan="2" style="text-align: left;"><span name="attr_INFOMSG"></span></td>
           </tr>
         </table>
       </div>
@@ -795,7 +803,7 @@
           <table class="sheet-tabsep">
             <tr>
               <td>
-                <button type="roll" class="sheet-neutre" name="roll_jetcapa" title="%{repeating_jetcapas_$N_jetcapa}" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{subtags=Capacité}} {{name=@{jetcapanom} @{jetcapalim}}} {{carac=[[@{jetcapanbde}d@{jetcapade}@{jetcapatypjet} + [[@{jetcapacarac}]] + @{jetcapadiv}]] }} {{jet=@{jetcapatitre}}} {{desc=@{jetcapavoie}}} {{text=@{jetcapadesc}}}" />
+                <button type="roll" class="sheet-neutre" name="roll_pjcapa" title="%{repeating_jetcapas_$N_pjcapa}" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{subtags=Capacité}} {{name=@{jetcapanom} @{jetcapalim}}} {{carac=[[@{jetcapanbde}d@{jetcapade}@{jetcapatypjet} + [[@{jetcapacarac}]] + @{jetcapadiv}]] }} {{jet=@{jetcapatitre}}} {{desc=@{jetcapavoie}}} {{text=@{jetcapadesc}}}" />
               </td>
               <td class="sheet-boxinputleft" style="min-width:200px;">
                 <input type="text" name="attr_jetcapanom" title="@{jetcapanom}" style="font-weight: bold;" placeholder="Nom du jet de capacité" />
@@ -869,7 +877,7 @@
           <table class="sheet-tabsep">
             <tr>
               <td style="width: 15px;">
-                <button type="roll" name="roll_trait" title="%{repeating_traits_$N_trait}" class="sheet-output" value="/w &quot;@{character_name}&quot; &{template:co1} {{perso=@{character_name}}} {{name=@{traitnom}}} {{subtags=@{traittype}}} {{text=@{traitdesc}}}">w</button>
+                <button type="roll" name="roll_pjtrait" title="%{repeating_traits_$N_pjtrait}" class="sheet-output" value="/w &quot;@{character_name}&quot; &{template:co1} {{perso=@{character_name}}} {{name=@{traitnom}}} {{subtags=@{traittype}}} {{text=@{traitdesc}}}">w</button>
               </td>
               <td class="sheet-boxinputleft" style="width: 200px;"><input type="text" style="font-weight: bold;" name="attr_traitnom" placeholder="Nom du trait" title="@{traitnom}" /></td>
               <td class="sheet-boxinputleft" style="width: 150px;"><input type="text" name="attr_traittype" placeholder="Origine/Type de trait" title="@{traittype}" /></td>
@@ -963,7 +971,16 @@
               <input type="checkbox" name="attr_use_encombrement" title="@{use_encombrement} Gérer l'encombrement" value="1" />
             </td>
             <td style="width: 20%;">
-              <button type="action" class="sheet-iconbtn" name="act_reset" title="Re-calculer attributs (rangs, encombrement)">r</button>
+              <button type="action" class="sheet-iconbtn" name="act_reset_btn" title="Re-calculer attributs (rangs, encombrement)">r</button>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <span class="textbase">Progression PV :</span>&nbsp;
+              <select class="sheet-carac" style="width: 90px;" name="attr_prog_pv" title="@{prog_pv}" size="1">
+                <option value="0" selected>Jet DV</option>
+                <option value="1">Moyenne</option>
+              </select>
             </td>
           </tr>
         </table>
@@ -1037,6 +1054,16 @@
             <td style="width: 5%;">DEFPsy:</td>
             <td style="width: 90%;"><input class="sheet-buff" type="text" name="attr_DEP_BUFF_LIST" placeholder="<Type> : <Valeur>; <Type> <Valeur>..." /></td>
             <td style="width: 5%;"><input class="sheet-buff" type="number" name="attr_DEP_BUFFS" value="@{DEP_BUFF}" disabled /></td>
+          </tr>
+          <tr>
+            <td style="width: 5%;">PV:</td>
+            <td style="width: 90%;">
+              <input class="sheet-buff" type="text" name="attr_PV_BUFF_LIST"
+                placeholder="<Type> : <Valeur>; <Type> <Valeur>..." />
+            </td>
+            <td style="width: 5%;">
+              <input class="sheet-buff" type="number" name="attr_PV_BUFFS" value="@{PV_BUFF}" disabled />
+            </td>
           </tr>
         </table>
       </div> <!-- FIN BUFFS -->
@@ -1289,7 +1316,7 @@
               <table class="sheet-tabsep">
                 <tr>
                   <td>
-                    <button type="roll" class="sheet-neutre" name="roll_atkv" title="%{repeating_armesv_$N_atkv}" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{subtags=Tir}} {{name=@{armenom}}} {{desc=@{armejetn}@{armecan_nom}}} {{attaque=[[@{armejetd}cs>@{armecrit}cf<@{armeinct}[Dé] + [[@{armeatk}]][Attaque] + @{armecan} + @{armeatkdiv}[Bonus] ]]}} {{degats=[[@{armedmnbde}d@{armedmde}[Dé DM] + [[@{armedmcar}]][Mod.DM] + @{armedmdiv}[Bonus DM] ]]}} {{special=@{armespec}}}" />
+                    <button type="roll" class="sheet-neutre" name="roll_vatk" title="%{repeating_armesv_$N_vatk}" value="@{togm}&{template:co1} {{perso=@{character_name}}} {{subtags=Tir}} {{name=@{armenom}}} {{desc=@{armejetn}@{armecan_nom}}} {{attaque=[[@{armejetd}cs>@{armecrit}cf<@{armeinct}[Dé] + [[@{armeatk}]][Attaque] + @{armecan} + @{armeatkdiv}[Bonus] ]]}} {{degats=[[@{armedmnbde}d@{armedmde}[Dé DM] + [[@{armedmcar}]][Mod.DM] + @{armedmdiv}[Bonus DM] ]]}} {{special=@{armespec}}}" />
                   </td>
                   <td class="sheet-boxinputleft" style="min-width: 140px;">
                     <input type="text" name="attr_armenom" title="@{armenom}" style="font-weight: bold;" placeholder="Arme/attaque" />
@@ -1719,7 +1746,7 @@
             <table class="sheet-tabsep">
               <tr>
                 <td style="width: 30px;">
-                  <button type="roll" class="sheet-neutre" style="width: 25px;" name="roll_atkpnj" title="%{repeating_pnjatk_$N_atkpnj}" value="@{pnj_togm}&{template:co1} {{perso=@{character_name}}} {{subtags=Attaque}} {{name=@{atknom}}} {{portee=@{atkportee}}} {{@{atkatt}[[@{atkjet}cf1cs>@{atkcrit}[Dé] + [[@{atkbonus}]][Attaque] ]]}} {{@{atkdmg}[[@{atkdmnbde}d@{atkdmde}[Dé DM] + [[@{atkdmbonus}]][Mod.DM] ]]}} {{special=@{atkspec}}}" />
+                  <button type="roll" class="sheet-neutre" style="width: 25px;" name="roll_pnjatk" title="%{repeating_pnjatk_$N_pnjatk}" value="@{pnj_togm}&{template:co1} {{perso=@{character_name}}} {{subtags=Attaque}} {{name=@{atknom}}} {{portee=@{atkportee}}} {{@{atkatt}[[@{atkjet}cf1cs>@{atkcrit}[Dé] + [[@{atkbonus}]][Attaque] ]]}} {{@{atkdmg}[[@{atkdmnbde}d@{atkdmde}[Dé DM] + [[@{atkdmbonus}]][Mod.DM] ]]}} {{special=@{atkspec}}}" />
                 </td>
                 <td class="sheet-boxinputleft" style="width: 250px;">
                   <input type="checkbox" name="attr_atkatt" title="@{atkatt} Faire un jet d'attaque pour toucher" value="attaque=" checked="checked" />
@@ -1973,1585 +2000,1862 @@
 
 <!-- **** SCRIPTS / SHEET WORKERS -->
 <script type="text/worker">
-  
-  function consoleLog(l, m) {
-    m = m || '';
-    if (m !== '') m = ' : ' + m;
-    console.log('** CO sheetworker' + m + ' <<<');
-    console.log(l);
-    console.log('** CO sheetworker' + m + ' >>>');
+
+function consoleLog(l, m) {
+  m = m || '';
+  if (m !== '') m = ' : ' + m;
+  console.log('** CO sheetworker' + m + ' <<<');
+  console.log(l);
+  console.log('** CO sheetworker' + m + ' >>>');
+}
+
+function addTrait(npcObj, traitObj) {
+  if (traitObj['nom'] !== '' && traitObj['desc'] !== '') {
+    if (!npcObj['Capas']) npcObj['Capas'] = [];
+    npcObj['Capas'].push(`${traitObj['nom']}~${traitObj['desc']}`);
+    traitObj['nom'] = '';
+    traitObj['desc'] = '';
+  }
+}
+
+function importStatblock(text) {
+  text = text.replace(/\r/g, '');
+  text = text.replace(/ \(DM/g, ' DM');
+  text = text.replace(/ \(RD/g, ' RD');
+  text = text.replace(/\, /g, ' ');
+  text = text.replace(/\n[ ]*\+/g, '+');
+  var npc = {};
+  var rows = text.split(/\n/);
+  var capacites = false;
+  var capacite = { 'nom': '', 'desc': '' };
+  console.log('** CO sheetworker : parsing text <<<');
+  rows.forEach(function (row, rownr) {
+    console.log(row);
+    if (rownr === 0 && row.toUpperCase().indexOf('NC') === -1) {
+      npc['character_name'] = row.trim(); // assume first line is name
+      return;
+    }
+    if (!capacites && row.toUpperCase().indexOf('DM') !== -1) { // this is an attack line
+      row = row.replace(/\)$/g, ''); // handle CG statblocks
+      if (!npc.Atks) npc.Atks = [];
+      npc.Atks.push(row);
+      return;
+    }
+    if (capacites) { // start parsing traits
+      let s = row.indexOf(':');
+      if (s !== -1) {
+        addTrait(npc, capacite);
+        capacite['nom'] = row.substring(0, s - 1).trim();
+        if (capacite['nom'].indexOf(' RD') !== -1) capacite['nom'] = capacite['nom'].replace(' RD', ' (RD');
+        capacite['desc'] = row.substring(s + 1).trim();
+      } else {
+        capacite['desc'] += ' ' + row.trim();
+      }
+      return;
+    }
+    if (row.trim().startsWith('---')) {
+      if (capacites) addTrait(npc, capacite);
+      capacites = !capacites;
+      return;
+    }
+    row = row.replace(/ \(/g, '('); // strip space before '(
+    row = row.replace(/très /g, 'très~'); // handle 'très petite' size
+    row = row.replace(/créature /g, 'PROFIL créature~'); // handle 'créature' mention
+    var items = row.split(' ');
+    for (var item = 0; item < items.length - 1; item++) {
+      if (item % 2 === 0) {
+        var k = items[item].toUpperCase().replace(/\./g, '');
+        var v = items[item + 1];
+        if (v) {
+          v.replace(/~/g, ' ');
+          if (v.charAt(v.length - 1) === ')' && v.charAt(0) !== '(') v = v.substring(0, v.length - 1);
+        } else {
+          v = '';
+        }
+        npc[k] = v;
+      }
+    }
+  });
+  if (capacites) addTrait(npc, capacite);
+  console.log('** CO sheetworker : parsing text >>>');
+  return npc;
+}
+
+function processBaseAttributes(universe, pnjObj) {
+  var result = '';
+  var pnj_sagorper = '';
+  var pnj_jetsagorper = '';
+  var pnj_sagper = 'pnj_per';
+  var pnj_jetsagper = 'pnj_jetper';
+  var sagOrPer = pnjObj.PER; //might be undefined
+  if (universe == 'COF') { // COF uses SAG (Wisdom)
+    pnj_sagper = 'pnj_sag';
+    pnj_jetsagper = 'pnj_jetsag';
+    if (!pnjObj.hasOwnProperty('SAG') && pnjObj.hasOwnProperty('PER')) {
+      // in case a CG/COC statblock is pasted to COF
+      sagOrPer = pnjObj.PER;
+      result = 'Attention : PER trouvé à la place de SAG';
+    } else {
+      sagOrPer = pnjObj.SAG;
+    }
+  }
+  if (universe == 'COC' || universe == 'CG') { // CG & COC uses PER (Perception)
+    pnj_sagper = 'pnj_per';
+    pnj_jetsagper = 'pnj_jetper';
+    if (!pnjObj.hasOwnProperty('PER') && pnjObj.hasOwnProperty('SAG')) {
+      // in case a COF statblock is pasted to CG/COC
+      sagOrPer = pnjObj.SAG;
+      result = 'Attention : SAG trouvé à la place de PER';
+    } else {
+      sagOrPer = pnjObj.PER;
+    }
+  }
+  var jnor = '1d20';
+  var jsup = '2d20kh1';
+  var pnjAttrs = {};
+  if (pnjObj.hasOwnProperty('character_name')) pnjAttrs['character_name'] = pnjObj.character_name;
+  delete pnjObj['character_name'];
+  pnjAttrs.NIVEAU = parseInt(pnjObj.NC) || 0;
+  delete pnjObj.NC;
+  pnjAttrs.TAILLE = pnjObj.TAILLE || '';
+  delete pnjObj.TAILLE;
+  if (pnjObj.hasOwnProperty('PROFIL')) pnjAttrs.PROFIL = pnjObj.PROFIL;
+  delete pnjObj.PROFIL;
+  pnjAttrs.pnj_for = parseInt(pnjObj.FOR.replace('*', ''));
+  pnjAttrs.pnj_jetfor = pnjObj.FOR.charAt(pnjObj.FOR.length - 1) == '*' ? jsup : jnor;
+  delete pnjObj.FOR;
+  pnjAttrs.pnj_dex = parseInt(pnjObj.DEX.replace('*', ''));
+  pnjAttrs.pnj_jetdex = pnjObj.DEX.charAt(pnjObj.DEX.length - 1) == '*' ? jsup : jnor;
+  delete pnjObj.DEX;
+  pnjAttrs.pnj_con = parseInt(pnjObj.CON.replace('*', ''));
+  pnjAttrs.pnj_jetcon = pnjObj.CON.charAt(pnjObj.CON.length - 1) == '*' ? jsup : jnor;
+  delete pnjObj.CON;
+  pnjAttrs.pnj_int = parseInt(pnjObj.INT.replace('*', ''));
+  pnjAttrs.pnj_jetint = pnjObj.INT.charAt(pnjObj.INT.length - 1) == '*' ? jsup : jnor;
+  delete pnjObj.INT;
+  pnjAttrs[pnj_sagper] = parseInt(sagOrPer.replace('*', ''));
+  pnjAttrs[pnj_jetsagper] = sagOrPer.charAt(sagOrPer.length - 1) == '*' ? jsup : jnor;
+  delete pnjObj.SAG;
+  delete pnjObj.PER;
+  pnjAttrs.pnj_cha = parseInt(pnjObj.CHA.replace('*', ''));
+  pnjAttrs.pnj_jetcha = pnjObj.CHA.charAt(pnjObj.CHA.length - 1) == '*' ? jsup : jnor;
+  delete pnjObj.CHA;
+  pnjAttrs.pnj_init = parseInt(pnjObj.INIT);
+  delete pnjObj.INIT;
+  pnjAttrs.pnj_def = parseInt(pnjObj.DEF);
+  delete pnjObj.DEF;
+  if (pnjObj.hasOwnProperty('DEP')) {
+    pnjAttrs.pnj_dep = parseInt(pnjObj.DEP);
+    delete pnjObj.DEP;
+  }
+  pnjAttrs.pnj_pv = parseInt(pnjObj.PV);
+  pnjAttrs.pnj_pv_max = parseInt(pnjObj.PV);
+  delete pnjObj.PV;
+  consoleLog(pnjAttrs, 'setting attributes');
+  pnjAttrs.statblock = '';
+  setAttrs(pnjAttrs);
+  return result;
+}
+
+function processAttacks(universe, pnjObj) {
+  var result = '';
+  for (var atk = 0; atk < pnjObj.Atks.length; atk++) {
+    var atkItems = pnjObj.Atks[atk].split(' ');
+    consoleLog(atkItems, 'attacks found');
+    if (atkItems[atkItems.length - 1] == 'DM') atkItems.push('-');
+    var atkAtt = 'attaque=';
+    var atkNom = '';
+    var atkBonus = -1;
+    var atkDM = '';
+    var atkSpec = '';
+    var parsed = '';
+    for (var item = 0; item < atkItems.length; item++) {
+      if (atkItems[item] == 'DM' && atkNom == '') {
+        atkNom = parsed;
+        parsed = 'DM';
+        continue;
+      }
+      if (atkItems[item].charAt(0) == '+' && atkItems[item] != '+' && atkNom == '') {
+        atkBonus = parseInt(atkItems[item].replace('+', '')) || 0;
+        atkNom = parsed;
+        parsed = '';
+        continue;
+      }
+      if (parsed.endsWith('DM')) {
+        atkDM = atkItems[item];
+        atkSpec = parsed.replace('DM', '');
+        parsed = '';
+        continue;
+      }
+      parsed += parsed != '' ? ' ' : '';
+      parsed += atkItems[item];
+    }
+    consoleLog(atkNom + ' ' + atkBonus + ' ' + atkDM + ' ' + atkSpec);
+    if (atkBonus == -1) atkAtt = '0'; // No attack bonus found, damage only
+    var atkDmg = 'degats=';
+    var atkNbDe = 0;
+    var atkDe = '';
+    var atkBonusDM = 0;
+    if (atkDM != '') {
+      atkDM = atkDM.replace('d', '|');
+      atkDM = atkDM.replace('+', '|+');
+      atkDM = atkDM.replace('-', '|-');
+      var dm = atkDM.split('|');
+      atkNbDe = parseInt(dm[0]) || 0;
+      if (atkNbDe == 0) atkDmg = '0'; // No damage dice, attack only
+      atkDe = dm[1];
+      if (universe === 'COC') atkDe += '!';
+      atkBonusDM = parseInt(dm[2]) || 0;
+    }
+    if (atkNom != '' && atkNbDe >= 0 && atkDe != '') {
+      newRowID = generateRowID();
+      var atkRow = {};
+      atkRow[`repeating_pnjatk_${newRowID}_atkatt`] = atkAtt;
+      atkRow[`repeating_pnjatk_${newRowID}_atknom`] = atkNom;
+      atkRow[`repeating_pnjatk_${newRowID}_atkjet`] = '1d20';
+      atkRow[`repeating_pnjatk_${newRowID}_atkbonus`] = atkBonus;
+      atkRow[`repeating_pnjatk_${newRowID}_atkcrit`] = '20';
+      atkRow[`repeating_pnjatk_${newRowID}_atkdmg`] = atkDmg;
+      atkRow[`repeating_pnjatk_${newRowID}_atkdmnbde`] = atkNbDe;
+      atkRow[`repeating_pnjatk_${newRowID}_atkdmde`] = atkDe;
+      atkRow[`repeating_pnjatk_${newRowID}_atkdmbonus`] = atkBonusDM;
+      atkSpec += parsed;
+      atkSpec = atkSpec.replace(/\d+d\d+/g, '[[$&]]'); // search for <numbers>d<numbers> and replace with in-line roll
+      if (atkSpec != '') atkRow[`repeating_pnjatk_${newRowID}_atkspec`] = atkSpec;
+      consoleLog(atkRow, 'adding attack');
+      setAttrs(atkRow);
+    } else {
+      result += (result.length > 0 ? '\n' : '') + 'Err: impossible d\'analyser le contenu de "' + pnjObj.Atks[atk] + '"';
+    }
+  }
+  for (let attr of ['ATP(PER)', 'ATP(CHA)']) {
+    if (pnjObj.hasOwnProperty(attr)) {
+      newRowID = generateRowID();
+      let atkRow = {};
+      atkRow[`repeating_pnjatk_${newRowID}_atkatt`] = atkAtt;
+      if (attr === 'ATP(PER)') {
+        atkRow[`repeating_pnjatk_${newRowID}_atknom`] = 'Psy Intuition';
+      } else if (attr === 'ATP(CHA)') {
+        atkRow[`repeating_pnjatk_${newRowID}_atknom`] = 'Psy Influence';
+      } else {
+        continue;
+      }
+      atkRow[`repeating_pnjatk_${newRowID}_atkjet`] = '1d20';
+      atkRow[`repeating_pnjatk_${newRowID}_atkbonus`] = parseInt(pnjObj[attr]);
+      atkRow[`repeating_pnjatk_${newRowID}_atkcrit`] = '20';
+      atkRow[`repeating_pnjatk_${newRowID}_atkdmg`] = '0';
+      atkRow[`repeating_pnjatk_${newRowID}_atkdmnbde`] = 0;
+      atkRow[`repeating_pnjatk_${newRowID}_atkdmde`] = '';
+      atkRow[`repeating_pnjatk_${newRowID}_atkdmbonus`] = 0;
+      consoleLog(atkRow, 'adding attack');
+      setAttrs(atkRow);
+      delete pnjObj[attr];
+    }
+  }
+  return result;
+}
+
+function processTraits(universe, pnjObj) {
+  let result = '';
+  for (let capa of pnjObj['Capas']) {
+    let capacite = capa.split('~')
+    if (capacite.length == 2) {
+      let name = capacite[0] || '';
+      let desc = capacite[1] || '';
+      if (name !== '' && desc !== '') {
+        newRowID = generateRowID();
+        let capaRow = {};
+        capaRow[`repeating_pnjcapas_${newRowID}_capanom`] = name;
+        desc = desc.replace(/\d+d\d+[+-]*\d*/g, '{{$&}}'); // search for <numbers>d<numbers>+/-<number> 
+        desc = desc.replace(/\[\d+d\d+[+-]*\d*\]/g, '{$&}'); // search for [<numbers>d<numbers>+/-<number>]
+        desc = desc.replace(/\[{{/g, '[[');
+        desc = desc.replace(/}}\]/g, ']]');
+        desc = desc.replace(/{{/g, '[[');
+        desc = desc.replace(/}}/g, ']]');
+        capaRow[`repeating_pnjcapas_${newRowID}_capadesc`] = desc;
+        consoleLog(capaRow, 'adding trait');
+        setAttrs(capaRow);
+      }
+    } else {
+      result += (result.length > 0 ? '\n' : '') + 'Err: impossible d\'analyser le contenu de "' + capacite + '"';
+    }
   }
 
-  // C# String.Format() emulation
-  function stringFormat(s) {
-    var s = arguments[0];
-    for (a = 0; a < arguments.length - 1; a++) {
-      s = s.replace(new RegExp('\\{' + a + '\\}' ,'g'), arguments[a+1]);
+  return result;
+}
+
+function buildCaracs() {
+  getAttrs([
+    'FORCE', 'DEXTERITE', 'CONSTITUTION', 'INTELLIGENCE', 'PERCEPTION', 'CHARISME', 'NIVEAU',
+    'RANG_VOIE1', 'RANG_VOIE2', 'RANG_VOIE3', 'RANG_VOIE4', 'RANG_VOIE5', 'RANG_VOIE6', 'RANG_VOIE7', 'RANG_VOIE8', 'RANG_VOIE9',
+    'voie1nom', 'voie2nom', 'voie3nom', 'voie4nom', 'voie5nom', 'voie6nom', 'voie7nom', 'voie8nom', 'voie9nom'
+  ], function (values) {
+    let caracs = {
+      FOR: 0,
+      DEX: 0,
+      CON: 0,
+      INT: 0,
+      PER: 0,
+      CHA: 0
+    };
+    for (let car in values) {
+      let vcar = values[car];
+      if (vcar && !isNaN(vcar)) vcar = parseInt(vcar) || 0;
+      let mod = car.substring(0, 3);
+      if (caracs.hasOwnProperty(mod)) caracs[mod] = Math.floor((vcar - 10) / 2);
+      if (car.startsWith('RANG_')) {
+        if (!caracs.hasOwnProperty('rangs')) caracs.rangs = [0, 0, 0, 0, 0, 0, 0, 0, 0];
+        let voie = parseInt(car.substring(car.length - 1)) || 0;
+        if (voie > 0) caracs.rangs[voie - 1] = vcar;
+      } else if (car.startsWith('voie') && car.endsWith('nom')) {
+        if (!caracs.hasOwnProperty('voies')) caracs.voies = ['', '', '', '', '', '', '', '', ''];
+        let voie = parseInt(car.substring(4, 5)) || 0;
+        if (voie > 0 && vcar) caracs.voies[voie - 1] = vcar.toUpperCase();
+      } else {
+        caracs[car] = vcar;
+      }
     }
-    return s;
-  }
-  
-  function addTrait(npcObj, traitObj) {
-    if (traitObj['nom'] !== '' && traitObj['desc'] !== '') {
-      if (!npcObj['Capas']) npcObj['Capas'] = [];
-      npcObj['Capas'].push(`${traitObj['nom']}~${traitObj['desc']}`);
-      traitObj['nom'] = '';
-      traitObj['desc'] = '';
-    }
-  }
-  
-  function importStatblock(text) {
-    text = text.replace(/\r/g, '');
-    text = text.replace(/ \(DM/g, ' DM');
-    text = text.replace(/ \(RD/g, ' RD');
-    text = text.replace(/\, /g, ' ');
-    text = text.replace(/\n[ ]*\+/g,'+');
-    var npc = {};
-    var rows = text.split(/\n/);
-    var capacites = false;
-    var capacite = { 'nom': '', 'desc': '' };
-    console.log('** CO sheetworker : parsing text <<<');
-    rows.forEach(function(row, rownr) {
-      console.log(row);
-      if (rownr === 0 && row.toUpperCase().indexOf('NC') === -1) {
-        npc['character_name'] = row.trim(); // assume first line is name
-        return;
-      }
-      if (!capacites && row.toUpperCase().indexOf('DM') !== -1) { // this is an attack line
-        row = row.replace(/\)$/g, ''); // handle CG statblocks
-        if (!npc.Atks) npc.Atks = [];
-        npc.Atks.push(row);
-        return;
-      }
-      if (capacites) { // start parsing traits
-        let s = row.indexOf(':');
-        if (s !== -1) {
-          addTrait(npc, capacite); 
-          capacite['nom'] = row.substring(0, s - 1).trim();
-          if (capacite['nom'].indexOf(' RD') !== -1) capacite['nom'] = capacite['nom'].replace(' RD', ' (RD');
-          capacite['desc'] = row.substring(s + 1).trim();
-        } else {
-          capacite['desc'] += ' ' + row.trim();
-        }
-        return;
-      }
-      if (row.trim().startsWith('---')) {
-        if (capacites) addTrait(npc, capacite);
-        capacites = !capacites;
-        return;
-      }
-      row = row.replace(/ \(/g, '('); // strip space before '(
-      row = row.replace(/très /g, 'très~'); // handle 'très petite' size
-      row = row.replace(/créature /g, 'PROFIL créature~'); // handle 'créature' mention
-      var items = row.split(' ');
-      for (var item = 0; item < items.length-1; item++) {
-        if (item % 2 === 0) {
-          var k = items[item].toUpperCase().replace(/\./g, '');
-          var v = items[item + 1];
-          if (v) {
-            v.replace(/~/g, ' ');
-            if (v.charAt(v.length - 1) === ')' && v.charAt(0) !== '(') v = v.substring(0, v.length - 1);
-          } else {
-            v = '';
-          }
-          npc[k] = v;
-        }
-      }
+    setAttrs({
+      CARACS: JSON.stringify(caracs)
     });
-    if (capacites) addTrait(npc, capacite);
-    console.log('** CO sheetworker : parsing text >>>');
-    return npc;
-  }
+  });
+}
 
-  function processBaseAttributes(universe, pnjObj) {
-    var result = '';
-    var pnj_sagorper = '';
-    var pnj_jetsagorper = '';
-    var pnj_sagper = 'pnj_per';
-    var pnj_jetsagper = 'pnj_jetper';
-    var sagOrPer = pnjObj.PER; //might be undefined
-    if (universe == 'COF') { // COF uses SAG (Wisdom)
-      pnj_sagper = 'pnj_sag';
-      pnj_jetsagper = 'pnj_jetsag';
-      if (!pnjObj.hasOwnProperty('SAG') && pnjObj.hasOwnProperty('PER')) {
-        // in case a CG/COC statblock is pasted to COF
-        sagOrPer = pnjObj.PER;
-        result = 'Attention : PER trouvé à la place de SAG';
-      } else {
-        sagOrPer = pnjObj.SAG;
-      }
-    }
-    if (universe == 'COC' || universe == 'CG') { // CG & COC uses PER (Perception)
-      pnj_sagper = 'pnj_per';
-      pnj_jetsagper = 'pnj_jetper';
-      if (!pnjObj.hasOwnProperty('PER') && pnjObj.hasOwnProperty('SAG')) {
-        // in case a COF statblock is pasted to CG/COC
-        sagOrPer = pnjObj.SAG;
-        result = 'Attention : SAG trouvé à la place de PER';
-      } else {
-        sagOrPer = pnjObj.PER;
-      }
-    }
-    var jnor = '1d20';
-    var jsup = '2d20kh1';
-    var pnjAttrs = {};
-    if (pnjObj.hasOwnProperty('character_name')) pnjAttrs['character_name'] = pnjObj.character_name;
-    delete pnjObj['character_name'];
-    pnjAttrs.NIVEAU = parseInt(pnjObj.NC) || 0;
-    delete pnjObj.NC;
-    pnjAttrs.TAILLE = pnjObj.TAILLE || '';
-    delete pnjObj.TAILLE;
-    if (pnjObj.hasOwnProperty('PROFIL')) pnjAttrs.PROFIL = pnjObj.PROFIL;
-    delete pnjObj.PROFIL;
-    pnjAttrs.pnj_for = parseInt(pnjObj.FOR.replace('*', ''));
-    pnjAttrs.pnj_jetfor = pnjObj.FOR.charAt(pnjObj.FOR.length - 1) == '*' ? jsup : jnor;
-    delete pnjObj.FOR;
-    pnjAttrs.pnj_dex = parseInt(pnjObj.DEX.replace('*', ''));
-    pnjAttrs.pnj_jetdex = pnjObj.DEX.charAt(pnjObj.DEX.length - 1) == '*' ? jsup : jnor;
-    delete pnjObj.DEX;
-    pnjAttrs.pnj_con = parseInt(pnjObj.CON.replace('*', ''));
-    pnjAttrs.pnj_jetcon = pnjObj.CON.charAt(pnjObj.CON.length - 1) == '*' ? jsup : jnor;
-    delete pnjObj.CON;
-    pnjAttrs.pnj_int = parseInt(pnjObj.INT.replace('*', ''));
-    pnjAttrs.pnj_jetint = pnjObj.INT.charAt(pnjObj.INT.length - 1) == '*' ? jsup : jnor;
-    delete pnjObj.INT;
-    pnjAttrs[pnj_sagper] = parseInt(sagOrPer.replace('*', ''));
-    pnjAttrs[pnj_jetsagper] = sagOrPer.charAt(sagOrPer.length - 1) == '*' ? jsup : jnor;
-    delete pnjObj.SAG;
-    delete pnjObj.PER;
-    pnjAttrs.pnj_cha = parseInt(pnjObj.CHA.replace('*', ''));
-    pnjAttrs.pnj_jetcha = pnjObj.CHA.charAt(pnjObj.CHA.length - 1) == '*' ? jsup : jnor;
-    delete pnjObj.CHA;
-    pnjAttrs.pnj_init = parseInt(pnjObj.INIT);
-    delete pnjObj.INIT;
-    pnjAttrs.pnj_def = parseInt(pnjObj.DEF);
-    delete pnjObj.DEF;
-    if (pnjObj.hasOwnProperty('DEP')) {
-      pnjAttrs.pnj_dep = parseInt(pnjObj.DEP);
-      delete pnjObj.DEP;
-    }
-    pnjAttrs.pnj_pv = parseInt(pnjObj.PV);
-    pnjAttrs.pnj_pv_max = parseInt(pnjObj.PV);
-    delete pnjObj.PV;
-    consoleLog(pnjAttrs, 'setting attributes');
-    pnjAttrs.statblock = '';
-    setAttrs(pnjAttrs);
-    return result;
-  }
-
-  function processAttacks(universe, pnjObj) {
-    var result = '';
-    for (var atk = 0; atk < pnjObj.Atks.length; atk++) {
-      var atkItems = pnjObj.Atks[atk].split(' ');
-      consoleLog(atkItems, 'attacks found');
-      if (atkItems[atkItems.length - 1] == 'DM') atkItems.push('-');
-      var atkAtt = 'attaque=';
-      var atkNom = '';
-      var atkBonus = -1;
-      var atkDM = '';
-      var atkSpec = '';
-      var parsed = '';
-      for (var item = 0; item < atkItems.length; item++) {
-        if (atkItems[item] == 'DM' && atkNom == '') {
-          atkNom = parsed;
-          parsed = 'DM';
-          continue;
-        }
-        if (atkItems[item].charAt(0) == '+' && atkItems[item] != '+' && atkNom == '') {
-          atkBonus = parseInt(atkItems[item].replace('+', '')) || 0;
-          atkNom = parsed;
-          parsed = '';
-          continue;
-        }
-        if (parsed.endsWith('DM')) {
-          atkDM = atkItems[item];
-          atkSpec = parsed.replace('DM', '');
-          parsed = '';
-          continue;
-        }
-        parsed += parsed != '' ? ' ' : '';
-        parsed += atkItems[item];
-      }
-      consoleLog(atkNom + ' ' + atkBonus + ' ' + atkDM + ' ' + atkSpec);
-      if (atkBonus == -1) atkAtt = '0'; // No attack bonus found, damage only
-      var atkDmg = 'degats=';
-      var atkNbDe = 0;
-      var atkDe = '';
-      var atkBonusDM = 0;
-      if (atkDM != '') {
-        atkDM = atkDM.replace('d', '|');
-        atkDM = atkDM.replace('+', '|+');
-        atkDM = atkDM.replace('-', '|-');
-        var dm = atkDM.split('|');
-        atkNbDe = parseInt(dm[0]) || 0;
-        if (atkNbDe == 0) atkDmg = '0'; // No damage dice, attack only
-        atkDe = dm[1];
-        if (universe === 'COC') atkDe += '!';
-        atkBonusDM = parseInt(dm[2]) || 0;
-      }
-      if (atkNom != '' && atkNbDe >= 0 && atkDe != '') {
-        newRowID = generateRowID();
-        var atkRow = {};
-        atkRow[`repeating_pnjatk_${newRowID}_atkatt`] = atkAtt;
-        atkRow[`repeating_pnjatk_${newRowID}_atknom`] = atkNom;
-        atkRow[`repeating_pnjatk_${newRowID}_atkjet`] = '1d20';
-        atkRow[`repeating_pnjatk_${newRowID}_atkbonus`] = atkBonus;
-        atkRow[`repeating_pnjatk_${newRowID}_atkcrit`] = '20';
-        atkRow[`repeating_pnjatk_${newRowID}_atkdmg`] = atkDmg;
-        atkRow[`repeating_pnjatk_${newRowID}_atkdmnbde`] = atkNbDe;
-        atkRow[`repeating_pnjatk_${newRowID}_atkdmde`] = atkDe;
-        atkRow[`repeating_pnjatk_${newRowID}_atkdmbonus`] = atkBonusDM;
-        atkSpec += parsed;
-        atkSpec = atkSpec.replace(/\d+d\d+/g, '[[$&]]'); // search for <numbers>d<numbers> and replace with in-line roll
-        if (atkSpec != '') atkRow[`repeating_pnjatk_${newRowID}_atkspec`] = atkSpec;
-        consoleLog(atkRow, 'adding attack');
-        setAttrs(atkRow);
-      } else {
-        result += (result.length > 0 ? '\n' : '') + 'Err: impossible d\'analyser le contenu de "' + pnjObj.Atks[atk] + '"';
-      }
-    }
-    for (let attr of ['ATP(PER)', 'ATP(CHA)']) {
-      if (pnjObj.hasOwnProperty(attr)) {
-        newRowID = generateRowID();
-        let atkRow = {};
-        atkRow[`repeating_pnjatk_${newRowID}_atkatt`] = atkAtt;
-        if (attr === 'ATP(PER)') {
-          atkRow[`repeating_pnjatk_${newRowID}_atknom`] = 'Psy Intuition';
-        } else if (attr === 'ATP(CHA)') {
-          atkRow[`repeating_pnjatk_${newRowID}_atknom`] = 'Psy Influence';
+on('sheet:opened', function () {
+  // **** Gestion transition de version
+  getAttrs(["VERSION"], function (values) {
+    var verfdp = parseFloat(values.VERSION) || 0;
+    if (verfdp === 0) {
+      // Version 1.6 vers 1.7
+      getAttrs(["FOR_SUP", "DEX_SUP", "CON_SUP", "INT_SUP", "PER_SUP", "CHA_SUP"], function (jets) {
+        var sfor, sdex, scon, sint, sper, scha = "";
+        if (jets.FOR_SUP == "2") {
+          sfor = "@{JETSUP}";
         } else {
-          continue;
+          sfor = "@{JETNORMAL}";
         }
-        atkRow[`repeating_pnjatk_${newRowID}_atkjet`] = '1d20';
-        atkRow[`repeating_pnjatk_${newRowID}_atkbonus`] = parseInt(pnjObj[attr]);
-        atkRow[`repeating_pnjatk_${newRowID}_atkcrit`] = '20';
-        atkRow[`repeating_pnjatk_${newRowID}_atkdmg`] = '0';
-        atkRow[`repeating_pnjatk_${newRowID}_atkdmnbde`] = 0;
-        atkRow[`repeating_pnjatk_${newRowID}_atkdmde`] = '';
-        atkRow[`repeating_pnjatk_${newRowID}_atkdmbonus`] = 0;
-        consoleLog(atkRow, 'adding attack');
-        setAttrs(atkRow);
-        delete pnjObj[attr];
-      }
+        if (jets.DEX_SUP == "2") {
+          sdex = "@{JETSUP}";
+        } else {
+          sdex = "@{JETNORMAL}";
+        }
+        if (jets.CON_SUP == "2") {
+          scon = "@{JETSUP}";
+        } else {
+          scon = "@{JETNORMAL}";
+        }
+        if (jets.INT_SUP == "2") {
+          sint = "@{JETSUP}";
+        } else {
+          sint = "@{JETNORMAL}";
+        }
+        if (jets.PER_SUP == "2") {
+          sper = "@{JETSUP}";
+        } else {
+          sper = "@{JETNORMAL}";
+        }
+        if (jets.CHA_SUP == "2") {
+          scha = "@{JETSUP}";
+        } else {
+          scha = "@{JETNORMAL}";
+        }
+        setAttrs({
+          FOR_SUP: sfor,
+          DEX_SUP: sdex,
+          CON_SUP: scon,
+          INT_SUP: sint,
+          PER_SUP: sper,
+          CHA_SUP: scha,
+          VERSION: "2.0"
+        });
+      });
     }
-    return result;
-  }
-  
-  function processTraits(universe, pnjObj) {
-    let result = '';
-     for (let capa of pnjObj['Capas']) {
-      let capacite = capa.split('~')
-      if (capacite.length == 2) {
-        let name = capacite[0] || '';
-        let desc = capacite[1] || '';
-        if (name !== '' && desc !== '') {
+    if (verfdp < 3) { // version 2.0 > 3.0
+      getAttrs(['UNIVERS', 'FOR_BONUS', 'DEX_BONUS', 'CON_BONUS', 'INT_BONUS', 'PER_BONUS', 'CHA_BONUS', 'ATKCAC_DIV', 'ATKTIR_DIV', 'ATKMAG_DIV', 'ATKMEN_DIV', 'PSYINTUI_DIV', 'PSYINFLU_DIV', 'INIT_DIV', 'DEFDIV', 'DEPDIV'], function (values) {
+        var for_bonus_desc = '',
+          for_bonus = parseInt(values.FOR_BONUS) || 0;
+        if (for_bonus !== 0) for_bonus_desc = 'Bonus FOR';
+        var dex_bonus_desc = '',
+          dex_bonus = parseInt(values.DEX_BONUS) || 0;
+        if (dex_bonus !== 0) dex_bonus_desc = 'Bonus DEX';
+        var con_bonus_desc = '',
+          con_bonus = parseInt(values.CON_BONUS) || 0;
+        if (con_bonus !== 0) con_bonus_desc = 'Bonus CON';
+        var int_bonus_desc = '',
+          int_bonus = parseInt(values.INT_BONUS) || 0;
+        if (int_bonus !== 0) int_bonus_desc = 'Bonus INT';
+        var per_bonus_desc = '',
+          per_bonus = parseInt(values.PER_BONUS) || 0;
+        if (per_bonus !== 0) per_bonus_desc = 'Bonus PER';
+        var cha_bonus_desc = '',
+          cha_bonus = parseInt(values.CHA_BONUS) || 0;
+        if (cha_bonus !== 0) cha_bonus_desc = 'Bonus CHA';
+        var atkcac_bonus_desc = '',
+          atkcac_div = parseInt(values.ATKCAC_DIV) || 0;
+        if (atkcac_div !== 0) atkcac_bonus_desc = 'Bonus ATC';
+        var atktir_bonus_desc = '',
+          atktir_div = parseInt(values.ATKTIR_DIV) || 0;
+        if (atktir_div !== 0) atktir_bonus_desc = 'Bonus ATD';
+        var atkmag_bonus_desc = '',
+          atkmag_div = parseInt(values.ATKMAG_DIV) || 0;
+        if (atkmag_div !== 0) atkmag_bonus_desc = 'Bonus MAG';
+        var atkmen_bonus_desc = '',
+          atkmen_div = parseInt(values.ATKMEN_DIV) || 0;
+        if (atkmen_div !== 0) atkmen_bonus_desc = 'Bonus MEN';
+        var psyinflu_bonus_desc = '',
+          psyinflu_div = parseInt(values.ATKPSYINFLU_DIV) || 0;
+        if (psyinflu_div !== 0) psyinflu_bonus_desc = 'Bonus Psy Inf.';
+        var psyintui_bonus_desc = '',
+          psyintui_div = parseInt(values.ATKPSYINTUI_DIV) || 0;
+        if (psyintui_div !== 0) psyintui_bonus_desc = 'Bonus Psy Int.';
+        var init_bonus_desc = '',
+          init_div = parseInt(values.INIT_DIV) || 0;
+        if (init_div !== 0) init_bonus_desc = 'Bonus Init.';
+        var def_bonus_desc = '',
+          defdiv = parseInt(values.DEFDIV) || 0;
+        if (defdiv !== 0) def_bonus_desc = 'Bonus DEF';
+        var dep_bonus_desc = '',
+          depdiv = parseInt(values.DEPDIV) || 0;
+        if (depdiv !== 0) dep_bonus_desc = 'Bonus DEP';
+        setAttrs({
+          FOR_BUFF1_DESC: for_bonus_desc,
+          FOR_BUFF1: for_bonus,
+          FOR_BUFF: for_bonus,
+          DEX_BUFF1_DESC: dex_bonus_desc,
+          DEX_BUFF1: dex_bonus,
+          DEX_BUFF: dex_bonus,
+          CON_BUFF1_DESC: con_bonus_desc,
+          CON_BUFF1: con_bonus,
+          CON_BUFF: con_bonus,
+          INT_BUFF1_DESC: int_bonus_desc,
+          INT_BUFF1: int_bonus,
+          INT_BUFF: int_bonus,
+          PER_BUFF1_DESC: per_bonus_desc,
+          PER_BUFF1: per_bonus,
+          PER_BUFF: per_bonus,
+          CHA_BUFF1_DESC: cha_bonus_desc,
+          CHA_BUFF1: cha_bonus,
+          CHA_BUFF: cha_bonus,
+          ATKCAC_BUFF1_DESC: atkcac_bonus_desc,
+          ATKCAC_BUFF1: atkcac_div,
+          ATKCAC_BUFF: atkcac_div,
+          ATKTIR_BUFF1_DESC: atktir_bonus_desc,
+          ATKTIR_BUFF1: atktir_div,
+          ATKTIR_BUFF: atktir_div,
+          ATKMAG_BUFF1_DESC: atkmag_bonus_desc,
+          ATKMAG_BUFF1: atkmag_div,
+          ATKMAG_BUFF: atkmag_div,
+          ATKMEN_BUFF1_DESC: atkmen_bonus_desc,
+          ATKMEN_BUFF1: atkmen_div,
+          ATKMEN_BUFF: atkmen_div,
+          PSYINFLU_BUFF1_DESC: psyinflu_bonus_desc,
+          PSYINFLU_BUFF1: psyinflu_div,
+          PSYINFLU_BUFF: psyinflu_div,
+          PSYINTUI_BUFF1_DESC: psyintui_bonus_desc,
+          PSYINTUI_BUFF1: psyintui_div,
+          PSYINTUI_BUFF: psyintui_div,
+          INIT_BUFF1_DESC: init_bonus_desc,
+          INIT_BUFF1: init_div,
+          INIT_BUFF: init_div,
+          DEF_BUFF1_DESC: def_bonus_desc,
+          DEF_BUFF1: defdiv,
+          DEF_BUFF: defdiv,
+          DEP_BUFF1_DESC: dep_bonus_desc,
+          DEP_BUFF1: depdiv,
+          DEP_BUFF: depdiv,
+          ATKTIRV_BUFF: 0,
+          VERSION: '3.0'
+        });
+      });
+    }
+    if (verfdp < 3.4) { // version 3.3 > 3.4
+      getAttrs(['TRAITS'], function (values) {
+        var traits = values.TRAITS.split(':');
+        if (traits.length >= 2) {
           newRowID = generateRowID();
-          let capaRow = {};
-          capaRow[`repeating_pnjcapas_${newRowID}_capanom`] = name;
-          desc = desc.replace(/\d+d\d+[+-]*\d*/g, '{{$&}}'); // search for <numbers>d<numbers>+/-<number> 
-          desc = desc.replace(/\[\d+d\d+[+-]*\d*\]/g, '{$&}'); // search for [<numbers>d<numbers>+/-<number>]
-          desc = desc.replace(/\[{{/g, '[[');
-          desc = desc.replace(/}}\]/g, ']]');
-          desc = desc.replace(/{{/g, '[[');
-          desc = desc.replace(/}}/g, ']]');
-          capaRow[`repeating_pnjcapas_${newRowID}_capadesc`] = desc;
-          consoleLog(capaRow, 'adding trait');
-          setAttrs(capaRow);
+          var traitRow = {};
+          traitRow['repeating_traits_' + newRowID + '_traitnom'] = traits[0].trim();
+          traitRow['repeating_traits_' + newRowID + '_traittype'] = 'Race / Humain';
+          traits.splice(0, 1);
+          traitRow['repeating_traits_' + newRowID + '_traitdesc'] = traits.join(':').trim();
+          setAttrs(traitRow);
+          setAttrs({ VERSION: '3.4' });
         }
-      } else {
-        result += (result.length > 0 ? '\n' : '') + 'Err: impossible d\'analyser le contenu de "' + capacite + '"';
+      });
+    }
+    if (verfdp < 3.5) { // version 3.4 > 3.5
+      const attrList = ['FOR', 'DEX', 'CON', 'INT', 'PER', 'CHA', 'ATKCAC', 'ATKTIR', 'PSYINFLU', 'PSYINTUI', 'INIT', 'DEF', 'DEP'];
+      for (let a = 0; a < attrList.length; a++) {
+        let attr = attrList[a];
+        let attrDesc = [];
+        let attrVals = [];
+        for (let b = 1; b < 6; b++) {
+          attrDesc.push(`${attr}_BUFF${b}_DESC`);
+          attrVals.push(`${attr}_BUFF${b}`);
+        }
+        getAttrs([attr, ...attrDesc, ...attrVals], function (values) {
+          let attr = Object.keys(values)[0];
+          let buffList = [];
+          for (let b = 1; b < 6; b++) {
+            let desc = values[`${attr}_BUFF${b}_DESC`] || '';
+            let buff = values[`${attr}_BUFF${b}`] || 0;
+            if (desc !== '') buffList.push(`${desc} : ${buff}`);
+          }
+          let buffAttr = {};
+          buffAttr[`${attr}_BUFF_LIST`] = buffList.join(';');
+          setAttrs(buffAttr);
+        });
+      }
+      setAttrs({ VERSION: '3.5' });
+    }
+  });
+  // Activer Buffs PSY ou de vaisseau
+  getAttrs(['UNIVERS', 'type_personnage', 'PE_ONCE', 'FOR_BUFF1_DESC', 'DEX_BUFF1_DESC', 'INT_BUFF1_DESC', 'PER_BUFF1_DESC', 'CHA_BUFF1_DESC', 'ATKTIRV_BUFF1_DESC', 'INIT_BUFF1_DESC', 'DEFVPIL_BUFF1_DESC', 'DEFVPIL_BUFF2_DESC', 'DEFVSEN_BUFF1_DESC', 'DEFVSEN_BUFF2_DESC'], function (values) {
+    if (values.UNIVERS == 'CG') {
+      if (values.type_personnage == 'vaisseau' && values.PE_ONCE !== '') {
+        var for_buff_desc = (values.FOR_BUFF1_DESC) || values.PE_ONCE;
+        var dex_buff_desc = (values.DEX_BUFF1_DESC) || values.PE_ONCE;
+        var int_buff_desc = (values.INT_BUFF1_DESC) || values.PE_ONCE;
+        var per_buff_desc = (values.PER_BUFF1_DESC) || values.PE_ONCE;
+        var cha_buff_desc = (values.CHA_BUFF1_DESC) || values.PE_ONCE;
+        var atktirv_buff_desc = (values.ATKTIRV_BUFF1_DESC) || values.PE_ONCE;
+        var init_buff_desc = (values.INIT_BUFF1_DESC) || 'Valeur DEX pilote';
+        var defvpil_buff1_desc = (values.DEFVPIL_BUFF1_DESC) || 'Mod. DEX Pilote';
+        var defvpil_buff2_desc = (values.DEFVPIL_BUFF2_DESC) || 'Rang Pilotage';
+        var defvsen_buff1_desc = (values.DEFVSEN_BUFF1_DESC) || 'Mod. INT Scantech';
+        var defvsen_buff2_desc = (values.DEFVSEN_BUFF2_DESC) || 'Rang Electronique';
+        setAttrs({
+          FOR_BUFF1_DESC: for_buff_desc,
+          DEX_BUFF1_DESC: dex_buff_desc,
+          INT_BUFF1_DESC: int_buff_desc,
+          PER_BUFF1_DESC: per_buff_desc,
+          CHA_BUFF1_DESC: cha_buff_desc,
+          ATKTIRV_BUFF1_DESC: atktirv_buff_desc,
+          INIT_BUFF1_DESC: init_buff_desc,
+          DEFVPIL_BUFF1_DESC: defvpil_buff1_desc,
+          DEFVPIL_BUFF2_DESC: defvpil_buff2_desc,
+          DEFVSEN_BUFF1_DESC: defvsen_buff1_desc,
+          DEFVSEN_BUFF2_DESC: defvsen_buff2_desc,
+          PE_ONCE: '',
+          type_personnage: 'vaisseau'
+        });
       }
     }
-    
-    return result;
+  });
+  // MAJ Version, LAST_PV, message
+  getAttrs(['verfdp', 'PV'], function (values) {
+    setAttrs({
+      VERSION: values.verfdp,
+      LAST_PV: values.PV,
+      INFOMSG: ' '
+    });
+  });
+  // ARMURE_MALUS
+  getAttrs(['ARMURE_MALUS'], function (value) {
+    if (!value.ARMURE_MALUS) setArmorMalus();
+  });
+  // RANG_VOIE#
+  for (let voie = 1; voie <= 9; voie++) {
+    setRank(voie.toString());
   }
-  
-  function buildCaracs() {
-    getAttrs([
-      'FORCE', 'DEXTERITE', 'CONSTITUTION', 'INTELLIGENCE', 'PERCEPTION', 'CHARISME', 'NIVEAU',
-      'RANG_VOIE1', 'RANG_VOIE2', 'RANG_VOIE3', 'RANG_VOIE4', 'RANG_VOIE5', 'RANG_VOIE6', 'RANG_VOIE7', 'RANG_VOIE8', 'RANG_VOIE9',
-      'voie1nom', 'voie2nom', 'voie3nom', 'voie4nom', 'voie5nom', 'voie6nom', 'voie7nom', 'voie8nom', 'voie9nom'
-    ], function (values) {
-      let caracs = {
-        FOR: 0,
-        DEX: 0,
-        CON: 0,
-        INT: 0,
-        PER: 0,
-        CHA: 0
-      };
-      for (let car in values) {
-        let vcar = values[car];
-        if (vcar && !isNaN(vcar)) vcar = parseInt(vcar) || 0;
-        let mod = car.substring(0, 3);
-        if (caracs.hasOwnProperty(mod)) caracs[mod] = Math.floor((vcar - 10) / 2);
-        if (car.startsWith('RANG_')) {
-          if (!caracs.hasOwnProperty('rangs')) caracs.rangs = [0, 0, 0, 0, 0, 0, 0, 0, 0];
-          let voie = parseInt(car.substring(car.length - 1)) || 0;
-          if (voie > 0) caracs.rangs[voie - 1] = vcar;
-        } else if (car.startsWith('voie') && car.endsWith('nom')) {
-          if (!caracs.hasOwnProperty('voies')) caracs.voies = ['', '', '', '', '', '', '', '', ''];
-          let voie = parseInt(car.substring(4, 5)) || 0;
-          if (voie > 0 && vcar) caracs.voies[voie - 1] = vcar.toUpperCase();
-        } else {
-          caracs[car] = vcar;
+  // seuil_enc (if needed)
+  getAttrs(['seuil_enc', 'FORCE'], function (values) {
+    let seuil_enc = parseInt(values.seuil_enc) || 0;
+    if (seuil_enc === 0) {
+      setAttrs({
+        seuil_enc: parseInt(values.FORCE) || 0
+      });
+    }
+  });
+  // encombrement (refresh)
+  encumbrance();
+  // CARACS
+  buildCaracs();
+});
+
+on('change:character_name', function () {
+  getAttrs(['character_name'], function (values) {
+    var charName = values.character_name;
+    charName = charName.replace(/ "/g, ' «');
+    charName = charName.replace(/" /g, '» ');
+    setAttrs({ character_name: charName })
+  });
+});
+
+/**
+ * Buffs de personnage
+ */
+
+function buffValue(v, caracs) {
+  v = v.trim();
+  let bm = 1;
+  if (v.startsWith('-')) bm = -1;
+  if (v.indexOf('2[') !== -1) {
+    v = v.replace('2[', '[');
+    bm *= 2;
+  }
+  v = v.replace(/[\+\-\[\]]/g, '');
+  consoleLog(v);
+  if (isNaN(v)) {
+    // c'est une référence d'attribut
+    if (v.toUpperCase().startsWith('VOIE')) {
+      // c'est un rang dans une voie identifiée par son no
+      let rv = parseInt(v.substring(4).trim()) || 0;
+      if (rv > 0) bv = caracs.rangs[rv - 1];
+    } else if (v.toUpperCase().startsWith('RANG')) {
+      // c'est un rang dans une voie identifiée par son nom
+      let vname = v.substring(5).toUpperCase();
+      let vfound = -1;
+      for (let vn = 0; vn < caracs.voies.length; vn++) {
+        if (caracs.voies[vn] === vname) {
+          vfound = vn;
+          break;
+        }
+      }
+      if (vfound > -1) bv = caracs.rangs[vfound];
+    } else {
+      // c'est un mod. de carac
+      bv = caracs[v];
+    }
+  } else { // c'est une valeur fixe
+    bv = v;
+  }
+  return parseInt(bv) * bm || 0;
+}
+
+function parseBuff(buffAttr) {
+  getAttrs([`${buffAttr}_BUFF_LIST`, 'CARACS'], function (v) {
+    let buffAttr = Object.keys(v)[0];
+    let buffList = v[buffAttr];
+    let caracs = JSON.parse(v.CARACS);
+    let buffSum = 0;
+    if (buffList && buffList !== '') {
+      let buffs = buffList.split(';');
+      for (let b = 0; b < buffs.length; b++) {
+        let buff = buffs[b];
+        if (buff && buff !== '') {
+          let delim = (buff.indexOf(':') !== -1) ? ':' : ' ';
+          let buffv = buff.split(delim);
+          let buffName = '';
+          let buffVal = 0;
+          if (delim === ' ') {
+            buffVal = buffValue(buffv[buffv.length - 1], caracs);
+            buffv.pop();
+            buffName = buffv.join(' ').trim();
+          } else {
+            buffName = buffv[0].trim();
+            buffVal = buffValue(buffv[1], caracs);
+          }
+          consoleLog(buffName);
+          if (!buffName.startsWith('-')) buffSum += buffVal;
+        }
+      }
+    }
+    let attr = {};
+    attr[buffAttr.replace('_LIST', '')] = buffSum;
+    setAttrs(attr);
+  });
+}
+
+function updateBuffs(e) {
+  const caracs = ['FOR', 'DEX', 'CON', 'INT', 'PER', 'CHA'];
+  let mod = e.sourceAttribute.substring(0, 3).toUpperCase();
+  if (!caracs.includes(mod)) return;
+  const attrs = [...caracs, 'ATKCAC', 'ATKTIR', 'PSYINTUI', 'PSYINFLU', 'INIT', 'DEF', 'DEP'];
+  for (let a = 0; a < attrs.length; a++) {
+    attrs[a] = `${attrs[a]}_BUFF_LIST`;
+  }
+  attrs.unshift(mod);
+  getAttrs(attrs, function (values) {
+    let props = Object.keys(values);
+    for (let p = 1; p < props.length; p++) {
+      if (props[p].startsWith(props[0])) continue;
+      if (values[props[p]].indexOf(`[${props[0]}]`) !== -1) parseBuff(props[p].replace('_BUFF_LIST', ''));
+    }
+  });
+}
+
+on([
+  'change:force',
+  'change:dexterite',
+  'change:constitution',
+  'change:intelligence',
+  'change:perception',
+  'change:charisme',
+  'change:niveau',
+  'change:defarmureon',
+  'change:voie1nom',
+  'change:voie2nom',
+  'change:voie3nom',
+  'change:voie4nom',
+  'change:voie5nom',
+  'change:voie6nom',
+  'change:voie7nom',
+  'change:voie8nom',
+  'change:voie9nom',
+  'change:rang_voie1',
+  'change:rang_voie2',
+  'change:rang_voie3',
+  'change:rang_voie4',
+  'change:rang_voie5',
+  'change:rang_voie6',
+  'change:rang_voie7',
+  'change:rang_voie8',
+  'change:rang_voie9',
+].join(' '), function (eventInfo) {
+  // on reconstruit d'abord l'attribut caché CARACS...
+  buildCaracs();
+  // ... puis on met à jour les buffs qui contiennent une référence à la caractéristique modifiée
+  updateBuffs(eventInfo);
+});
+
+on('change:for_buff_list', function () {
+  parseBuff('FOR');
+});
+
+on('change:dex_buff_list', function () {
+  parseBuff('DEX');
+});
+
+on('change:con_buff_list', function () {
+  parseBuff('CON');
+});
+
+on('change:int_buff_list', function () {
+  parseBuff('INT');
+});
+
+on('change:per_buff_list', function () {
+  parseBuff('PER');
+});
+
+on('change:cha_buff_list', function () {
+  parseBuff('CHA');
+});
+
+on('change:atkcac_buff_list', function () {
+  parseBuff('ATKCAC');
+});
+
+on('change:atktir_buff_list', function () {
+  parseBuff('ATKTIR');
+});
+
+on('change:psyinflu_buff_list', function () {
+  parseBuff('PSYINFLU');
+});
+
+on('change:psyintui_buff_list', function () {
+  parseBuff('PSYINTUI');
+});
+
+on('change:init_buff_list', function () {
+  parseBuff('INIT');
+});
+
+on('change:def_buff_list', function () {
+  parseBuff('DEF');
+});
+
+on('change:dep_buff_list', function () {
+  parseBuff('DEP');
+});
+
+on('change:pv_buff_list', function () {
+  parseBuff('PV');
+});
+
+/**
+ * Buffs de vaisseau
+ */
+
+function attrBuff(attr) {
+  let attrs = [];
+  for (let b = 1; b < 6; b++) {
+    attrs.push(`${attr}_BUFF${b}`);
+  }
+  return attrs;
+}
+
+function setBuff(v, buffAttr) {
+  let buffVal = 0;
+  for (let attr = 1; attr < 6; attr++) {
+    buffVal += parseInt(v[`${buffAttr}_BUFF${attr}`]) || 0;
+  }
+  let buff = {};
+  buff[`${buffAttr}_BUFF`] = buffVal;
+  setAttrs(buff);
+}
+
+on([
+  'change:for_buff1',
+  'change:for_buff2',
+  'change:for_buff3',
+  'change:for_buff4',
+  'change:for_buff5'
+].join(' '), function () {
+  getAttrs(attrBuff('FOR'), function (values) {
+    setBuff(values, 'FOR');
+  });
+});
+
+on([
+  'change:dex_buff1',
+  'change:dex_buff2',
+  'change:dex_buff3',
+  'change:dex_buff4',
+  'change:dex_buff5'
+].join(' '), function () {
+  getAttrs(attrBuff('DEX'), function (values) {
+    setBuff(values, 'DEX');
+  });
+});
+
+on([
+  'change:con_buff1',
+  'change:con_buff2',
+  'change:con_buff3',
+  'change:con_buff4',
+  'change:con_buff5'
+].join(' '), function () {
+  getAttrs(attrBuff('CON'), function (values) {
+    setBuff(values, 'CON');
+  });
+});
+
+on([
+  'change:int_buff1',
+  'change:int_buff2',
+  'change:int_buff3',
+  'change:int_buff4',
+  'change:int_buff5'
+].join(' '), function () {
+  getAttrs(attrBuff('INT'), function (values) {
+    setBuff(values, 'INT');
+  });
+});
+
+on([
+  'change:per_buff1',
+  'change:per_buff2',
+  'change:per_buff3',
+  'change:per_buff4',
+  'change:per_buff5'
+].join(' '), function () {
+  getAttrs(attrBuff('PER'), function (values) {
+    setBuff(values, 'PER');
+  });
+});
+
+on([
+  'change:cha_buff1',
+  'change:cha_buff2',
+  'change:cha_buff3',
+  'change:cha_buff4',
+  'change:cha_buff5'
+].join(' '), function () {
+  getAttrs(attrBuff('CHA'), function (values) {
+    setBuff(values, 'CHA');
+  });
+});
+
+on([
+  'change:atktirv_buff1',
+  'change:atktirv_buff2',
+  'change:atktirv_buff3',
+  'change:atktirv_buff4',
+  'change:atktirv_buff5'
+].join(' '), function () {
+  getAttrs(attrBuff('ATKTIRV'), function (values) {
+    setBuff(values, 'ATKTIRV');
+  });
+});
+
+on([
+  'change:defvpil_buff1',
+  'change:defvpil_buff2',
+  'change:defvpil_buff3',
+  'change:defvpil_buff4',
+  'change:defvpil_buff5'
+].join(' '), function () {
+  getAttrs(attrBuff('DEFVPIL'), function (values) {
+    setBuff(values, 'DEFVPIL');
+  });
+});
+
+on([
+  'change:defvsen_buff1',
+  'change:defvsen_buff2',
+  'change:defvsen_buff3',
+  'change:defvsen_buff4',
+  'change:defvsen_buff5'
+].join(' '), function () {
+  getAttrs(attrBuff('DEFVSEN'), function (values) {
+    setBuff(values, 'DEFVSEN');
+  });
+});
+
+on([
+  'change:pev_buff1',
+  'change:pev_buff2',
+  'change:pev_buff3',
+  'change:pev_buff4',
+  'change:pev_buff5'
+].join(' '), function () {
+  getAttrs(attrBuff('PEV'), function (values) {
+    setBuff(values, 'PEV');
+  });
+});
+
+on('change:blessure', function () {
+  getAttrs(['BLESSURE'], function (values) {
+    var etatde = (values.BLESSURE == '1') ? '12' : '20';
+    setAttrs({
+      ETATDE: etatde
+    });
+  });
+});
+
+on('change:poisse', function () {
+  getAttrs(['POISSE'], function (values) {
+    var jetn = (values.POISSE == '1') ? '2d@{ETATDE}kl1' : '1d@{ETATDE}';
+    var jets = (values.POISSE == '1') ? '1d@{ETATDE}' : '2d@{ETATDE}kh1';
+    var jetsh = (values.POISSE == '1') ? '2d@{ETATDE}kh1' : '{2d@{ETATDE}kh1, 0d20+10}kh1';
+    var jetr = (values.POISSE == '1') ? '2d12kl1' : '1d12';
+    setAttrs({
+      JETNORMAL: jetn,
+      JETSUP: jets,
+      JETSUPHERO: jetsh,
+      JETRISQUE: jetr,
+      JDEX: jetn,
+      JDEXSUP: jets,
+      JDEXSUPHERO: jetsh,
+      JDEXRISQUE: jetr
+    });
+  });
+});
+
+on('change:statblock', function (eventInfo) {
+  if (eventInfo.newValue === '') return;
+  getAttrs(['UNIVERS', 'statblock'], function (values) {
+    var messages = '';
+    var pnjObj = importStatblock(values.statblock);
+    if (pnjObj) {
+      consoleLog(pnjObj, 'NPC object');
+      messages = processBaseAttributes(values.UNIVERS, pnjObj);
+      if (pnjObj.hasOwnProperty('Atks')) {
+        var result = processAttacks(values.UNIVERS, pnjObj);
+        if (result !== '' && messages !== '') result = '\n' + result;
+        messages += result;
+        delete pnjObj.Atks;
+      }
+      if (pnjObj.hasOwnProperty('Capas')) {
+        result = processTraits(values.UNIVERS, pnjObj);
+        if (result != '' && messages != '') result = '\n' + result;
+        messages += result;
+        delete pnjObj['Capas'];
+      }
+      // Other attributes go to DIVERS field
+      var divers = '';
+      var otherAttrs = Object.keys(pnjObj);
+      consoleLog(otherAttrs, 'additional data');
+      if (otherAttrs.length > 0) {
+        for (var other = 0; other < otherAttrs.length; other++) {
+          var k = otherAttrs[other];
+          divers += k + ' ' + pnjObj[k] + '\n';
         }
       }
       setAttrs({
-        CARACS: JSON.stringify(caracs)
+        pnj_divers: divers,
+        sbresult: messages
       });
-    });
-  }
-
-  on('sheet:opened', function() {
-    // **** Gestion transition de version
-    getAttrs(["VERSION"], function(values) {
-      var verfdp = parseFloat(values.VERSION) || 0;
-      if (verfdp === 0) {
-        // Version 1.6 vers 1.7
-        getAttrs(["FOR_SUP", "DEX_SUP", "CON_SUP", "INT_SUP", "PER_SUP", "CHA_SUP"], function(jets) {
-          var sfor, sdex, scon, sint, sper, scha = "";
-          if (jets.FOR_SUP == "2") {
-            sfor = "@{JETSUP}";
-          } else {
-            sfor = "@{JETNORMAL}";
-          }
-          if (jets.DEX_SUP == "2") {
-            sdex = "@{JETSUP}";
-          } else {
-            sdex = "@{JETNORMAL}";
-          }
-          if (jets.CON_SUP == "2") {
-            scon = "@{JETSUP}";
-          } else {
-            scon = "@{JETNORMAL}";
-          }
-          if (jets.INT_SUP == "2") {
-            sint = "@{JETSUP}";
-          } else {
-            sint = "@{JETNORMAL}";
-          }
-          if (jets.PER_SUP == "2") {
-            sper = "@{JETSUP}";
-          } else {
-            sper = "@{JETNORMAL}";
-          }
-          if (jets.CHA_SUP == "2") {
-            scha = "@{JETSUP}";
-          } else {
-            scha = "@{JETNORMAL}";
-          }
-          setAttrs({
-            FOR_SUP: sfor,
-            DEX_SUP: sdex,
-            CON_SUP: scon,
-            INT_SUP: sint,
-            PER_SUP: sper,
-            CHA_SUP: scha,
-            VERSION: "2.0"
-          });
-        });
-      }
-      if (verfdp < 3) { // version 2.0 > 3.0
-        getAttrs(['UNIVERS', 'FOR_BONUS', 'DEX_BONUS', 'CON_BONUS', 'INT_BONUS', 'PER_BONUS', 'CHA_BONUS', 'ATKCAC_DIV', 'ATKTIR_DIV', 'ATKMAG_DIV', 'ATKMEN_DIV', 'PSYINTUI_DIV', 'PSYINFLU_DIV', 'INIT_DIV', 'DEFDIV', 'DEPDIV'], function(values) {
-          var for_bonus_desc = '',
-            for_bonus = parseInt(values.FOR_BONUS) || 0;
-          if (for_bonus !== 0) for_bonus_desc = 'Bonus FOR';
-          var dex_bonus_desc = '',
-            dex_bonus = parseInt(values.DEX_BONUS) || 0;
-          if (dex_bonus !== 0) dex_bonus_desc = 'Bonus DEX';
-          var con_bonus_desc = '',
-            con_bonus = parseInt(values.CON_BONUS) || 0;
-          if (con_bonus !== 0) con_bonus_desc = 'Bonus CON';
-          var int_bonus_desc = '',
-            int_bonus = parseInt(values.INT_BONUS) || 0;
-          if (int_bonus !== 0) int_bonus_desc = 'Bonus INT';
-          var per_bonus_desc = '',
-            per_bonus = parseInt(values.PER_BONUS) || 0;
-          if (per_bonus !== 0) per_bonus_desc = 'Bonus PER';
-          var cha_bonus_desc = '',
-            cha_bonus = parseInt(values.CHA_BONUS) || 0;
-          if (cha_bonus !== 0) cha_bonus_desc = 'Bonus CHA';
-          var atkcac_bonus_desc = '',
-            atkcac_div = parseInt(values.ATKCAC_DIV) || 0;
-          if (atkcac_div !== 0) atkcac_bonus_desc = 'Bonus ATC';
-          var atktir_bonus_desc = '',
-            atktir_div = parseInt(values.ATKTIR_DIV) || 0;
-          if (atktir_div !== 0) atktir_bonus_desc = 'Bonus ATD';
-          var atkmag_bonus_desc = '',
-            atkmag_div = parseInt(values.ATKMAG_DIV) || 0;
-          if (atkmag_div !== 0) atkmag_bonus_desc = 'Bonus MAG';
-          var atkmen_bonus_desc = '',
-            atkmen_div = parseInt(values.ATKMEN_DIV) || 0;
-          if (atkmen_div !== 0) atkmen_bonus_desc = 'Bonus MEN';
-          var psyinflu_bonus_desc = '',
-            psyinflu_div = parseInt(values.ATKPSYINFLU_DIV) || 0;
-          if (psyinflu_div !== 0) psyinflu_bonus_desc = 'Bonus Psy Inf.';
-          var psyintui_bonus_desc = '',
-            psyintui_div = parseInt(values.ATKPSYINTUI_DIV) || 0;
-          if (psyintui_div !== 0) psyintui_bonus_desc = 'Bonus Psy Int.';
-          var init_bonus_desc = '',
-            init_div = parseInt(values.INIT_DIV) || 0;
-          if (init_div !== 0) init_bonus_desc = 'Bonus Init.';
-          var def_bonus_desc = '',
-            defdiv = parseInt(values.DEFDIV) || 0;
-          if (defdiv !== 0) def_bonus_desc = 'Bonus DEF';
-          var dep_bonus_desc = '',
-            depdiv = parseInt(values.DEPDIV) || 0;
-          if (depdiv !== 0) dep_bonus_desc = 'Bonus DEP';
-          setAttrs({
-            FOR_BUFF1_DESC: for_bonus_desc,
-            FOR_BUFF1: for_bonus,
-            FOR_BUFF: for_bonus,
-            DEX_BUFF1_DESC: dex_bonus_desc,
-            DEX_BUFF1: dex_bonus,
-            DEX_BUFF: dex_bonus,
-            CON_BUFF1_DESC: con_bonus_desc,
-            CON_BUFF1: con_bonus,
-            CON_BUFF: con_bonus,
-            INT_BUFF1_DESC: int_bonus_desc,
-            INT_BUFF1: int_bonus,
-            INT_BUFF: int_bonus,
-            PER_BUFF1_DESC: per_bonus_desc,
-            PER_BUFF1: per_bonus,
-            PER_BUFF: per_bonus,
-            CHA_BUFF1_DESC: cha_bonus_desc,
-            CHA_BUFF1: cha_bonus,
-            CHA_BUFF: cha_bonus,
-            ATKCAC_BUFF1_DESC: atkcac_bonus_desc,
-            ATKCAC_BUFF1: atkcac_div,
-            ATKCAC_BUFF: atkcac_div,
-            ATKTIR_BUFF1_DESC: atktir_bonus_desc,
-            ATKTIR_BUFF1: atktir_div,
-            ATKTIR_BUFF: atktir_div,
-            ATKMAG_BUFF1_DESC: atkmag_bonus_desc,
-            ATKMAG_BUFF1: atkmag_div,
-            ATKMAG_BUFF: atkmag_div,
-            ATKMEN_BUFF1_DESC: atkmen_bonus_desc,
-            ATKMEN_BUFF1: atkmen_div,
-            ATKMEN_BUFF: atkmen_div,
-            PSYINFLU_BUFF1_DESC: psyinflu_bonus_desc,
-            PSYINFLU_BUFF1: psyinflu_div,
-            PSYINFLU_BUFF: psyinflu_div,
-            PSYINTUI_BUFF1_DESC: psyintui_bonus_desc,
-            PSYINTUI_BUFF1: psyintui_div,
-            PSYINTUI_BUFF: psyintui_div,
-            INIT_BUFF1_DESC: init_bonus_desc,
-            INIT_BUFF1: init_div,
-            INIT_BUFF: init_div,
-            DEF_BUFF1_DESC: def_bonus_desc,
-            DEF_BUFF1: defdiv,
-            DEF_BUFF: defdiv,
-            DEP_BUFF1_DESC: dep_bonus_desc,
-            DEP_BUFF1: depdiv,
-            DEP_BUFF: depdiv,
-            ATKTIRV_BUFF: 0,
-            VERSION: '3.0'
-          });
-        });
-      }
-      if (verfdp < 3.4) { // version 3.3 > 3.4
-        getAttrs(['TRAITS'], function(values) {
-          var traits = values.TRAITS.split(':');
-          if (traits.length >= 2) {
-            newRowID = generateRowID();
-            var traitRow = {};
-            traitRow['repeating_traits_' + newRowID + '_traitnom'] = traits[0].trim();
-            traitRow['repeating_traits_' + newRowID + '_traittype'] = 'Race / Humain';
-            traits.splice(0,1);
-            traitRow['repeating_traits_' + newRowID + '_traitdesc'] = traits.join(':').trim();
-            setAttrs(traitRow);
-            setAttrs({ VERSION: '3.4' });
-          }
-        });
-      }
-      if (verfdp < 3.5) { // version 3.4 > 3.5
-        const attrList = ['FOR', 'DEX', 'CON', 'INT', 'PER', 'CHA', 'ATKCAC', 'ATKTIR', 'PSYINFLU', 'PSYINTUI', 'INIT', 'DEF', 'DEP'];
-        for (let a=0; a < attrList.length; a++) {
-          let attr = attrList[a];
-          let attrDesc = [];
-          let attrVals = [];
-          for (let b=1; b < 6; b++) {
-            attrDesc.push(`${attr}_BUFF${b}_DESC`);
-            attrVals.push(`${attr}_BUFF${b}`);
-          }
-          getAttrs([attr, ...attrDesc, ...attrVals], function(values) {
-            let attr = Object.keys(values)[0];
-            let buffList = [];
-            for (let b=1; b < 6; b++) {
-              let desc = values[`${attr}_BUFF${b}_DESC`] || '';
-              let buff = values[`${attr}_BUFF${b}`] || 0;
-              if (desc !== '') buffList.push(`${desc} : ${buff}`);
-            }
-            let buffAttr = {};
-            buffAttr[`${attr}_BUFF_LIST`] = buffList.join(';');
-            setAttrs(buffAttr);
-          });
-        }
-        setAttrs({ VERSION: '3.5' });
-      }
-    });
-    // Activer Buffs PSY ou de vaisseau
-    getAttrs(['UNIVERS', 'type_personnage', 'PE_ONCE', 'FOR_BUFF1_DESC', 'DEX_BUFF1_DESC', 'INT_BUFF1_DESC', 'PER_BUFF1_DESC', 'CHA_BUFF1_DESC', 'ATKTIRV_BUFF1_DESC', 'INIT_BUFF1_DESC', 'DEFVPIL_BUFF1_DESC', 'DEFVPIL_BUFF2_DESC', 'DEFVSEN_BUFF1_DESC', 'DEFVSEN_BUFF2_DESC'], function(values) {
-      if (values.UNIVERS == 'CG') {
-        if (values.type_personnage == 'vaisseau' && values.PE_ONCE !== '') {
-          var for_buff_desc = (values.FOR_BUFF1_DESC) || values.PE_ONCE;
-          var dex_buff_desc = (values.DEX_BUFF1_DESC) || values.PE_ONCE;
-          var int_buff_desc = (values.INT_BUFF1_DESC) || values.PE_ONCE;
-          var per_buff_desc = (values.PER_BUFF1_DESC) || values.PE_ONCE;
-          var cha_buff_desc = (values.CHA_BUFF1_DESC) || values.PE_ONCE;
-          var atktirv_buff_desc = (values.ATKTIRV_BUFF1_DESC) || values.PE_ONCE;
-          var init_buff_desc = (values.INIT_BUFF1_DESC) || 'Valeur DEX pilote';
-          var defvpil_buff1_desc = (values.DEFVPIL_BUFF1_DESC) || 'Mod. DEX Pilote';
-          var defvpil_buff2_desc = (values.DEFVPIL_BUFF2_DESC) || 'Rang Pilotage';
-          var defvsen_buff1_desc = (values.DEFVSEN_BUFF1_DESC) || 'Mod. INT Scantech';
-          var defvsen_buff2_desc = (values.DEFVSEN_BUFF2_DESC) || 'Rang Electronique';
-          setAttrs({
-            FOR_BUFF1_DESC: for_buff_desc,
-            DEX_BUFF1_DESC: dex_buff_desc,
-            INT_BUFF1_DESC: int_buff_desc,
-            PER_BUFF1_DESC: per_buff_desc,
-            CHA_BUFF1_DESC: cha_buff_desc,
-            ATKTIRV_BUFF1_DESC: atktirv_buff_desc,
-            INIT_BUFF1_DESC: init_buff_desc,
-            DEFVPIL_BUFF1_DESC: defvpil_buff1_desc,
-            DEFVPIL_BUFF2_DESC: defvpil_buff2_desc,
-            DEFVSEN_BUFF1_DESC: defvsen_buff1_desc,
-            DEFVSEN_BUFF2_DESC: defvsen_buff2_desc,
-            PE_ONCE: '',
-            type_personnage: 'vaisseau'
-          });
-        }
-      }
-    });
-    // MAJ Version, LAST_PV, message
-    getAttrs(['verfdp', 'PV'], function(values) {
-      setAttrs({ 
-        VERSION: values.verfdp,
-        LAST_PV: values.PV,
-        INFOMSG: ' '
-      });
-    });
-    // ARMURE_MALUS
-    getAttrs(['ARMURE_MALUS'], function(value) {
-      if (!value.ARMURE_MALUS) setArmorMalus();
-    });
-    // RANG_VOIE#
-    for (let voie=1; voie <= 9; voie++) {
-      setRank(voie.toString());
     }
-    // seuil_enc (if needed)
-    getAttrs(['seuil_enc', 'FORCE'], function(values) {
-      let seuil_enc = parseInt(values.seuil_enc) || 0;
-      if (seuil_enc === 0) {
-        setAttrs({
-          seuil_enc: parseInt(values.FORCE) || 0
+  });
+});
+
+const npcAtkAttribs = [
+  'atkatt',
+  'atknom',
+  'atkjet',
+  'atkbonus',
+  'atkcrit',
+  'atkdmg',
+  'atkdmnbde',
+  'atkdmde',
+  'atkdmbonus',
+  'atkportee',
+  'atkspec'
+]
+
+function convertToPC() {
+  getAttrs([
+    'pnj_for', 'pnj_dex', 'pnj_con', 'pnj_int', 'pnj_per', 'pnj_cha',
+    'pnj_jetfor', 'pnj_jetdex', 'pnj_jetcon', 'pnj_jetint', 'pnj_jetper', 'pnj_jetcha',
+    'pnj_init', 'pnj_def', 'pnj_dep', 'pnj_pv', 'pnj_pv_max'
+  ], function (values) {
+    let attrs = {};
+    for (let attr of ['FORCE', 'DEXTERITE', 'CONSTITUTION', 'INTELLIGENCE', 'PERCEPTION', 'CHARISME']) {
+      let attrv = parseInt(values[`pnj_${attr.substring(0, 3).toLowerCase()}`]) || 0;
+      attrs[attr] = 10 + (2 * attrv);
+      if (attr === 'DEXTERITE') {
+        let init = parseInt(values.pnj_init) || 0;
+        if (init === attrv + 1) {
+          attrs[attr]++;
+        } else {
+          attrs['INIT_BUFF_LIST'] = 'Bonus Init.';
+          attrs['INIT_BUFF'] = init - attrs[attr];
+        }
+        let defb = 10 + attrv;
+        let def = parseInt(values.pnj_def) || 0;
+        if (def !== defb) {
+          attrs['DEF_BUFF_LIST'] = 'Bonus DEF';
+          attrs['DEF_BUFF'] = def - defb;
+        }
+        attrs['DEX_SUP'] = (values['pnj_jetdex'] === '2d20kh1') ? '@{JDEXSUP}' : '@{JDEX}';
+      } else if (attr === 'CHARISME') {
+        let depb = 10 + attrv;
+        let dep = parseInt(values.pnj_dep) || 0;
+        if (dep !== depb) {
+          attrs['DEP_BUFF_LIST'] = 'Bonus DEP';
+          attrs['DEP_BUFF'] = dep - depb;
+        }
+      } else {
+        attrs[`${attr.substring(0, 3)}_SUP`] = (values[`pnj_jet${attr.substring(0, 3).toLowerCase()}`] === '2d20kh1') ? '@{JETSUP}' : '@{JETNORMAL}';
+      }
+    }
+    attrs['PV'] = parseInt(values.pnj_pv) || 0;
+    attrs['PV_max'] = parseInt(values.pnj_pv_max) || 0;
+    getSectionIDs('repeating_armes', function (ids) {
+      for (let id of ids) {
+        removeRepeatingRow(`repeating_armes_${id}`);
+      }
+    });
+    getSectionIDs('repeating_pnjatk', function (ids) {
+      for (let id of ids) {
+        getAttrs([...npcAtkAttribs.map(attr => `repeating_pnjatk_${id}_${attr}`), 'pnj_for', 'pnj_dex', 'pnj_cha'], function (values) {
+          consoleLog(values);
+          let v = {};
+          for (let attr of npcAtkAttribs) {
+            v[attr] = values[`repeating_pnjatk_${id}_${attr}`] || '';
+          }
+          newRowID = generateRowID();
+          let atkRow = {};
+          atkRow[`repeating_armes_${newRowID}_armeatt`] = v['atkatt'];
+          atkRow[`repeating_armes_${newRowID}_armenom`] = v['atknom'];
+          let psyint = v['atknom'].toLowerCase().includes('psy intuition');
+          let psyinf = v['atknom'].toLowerCase().includes('psy influence');
+          let tohit = parseInt(v['atkbonus']) || 0;
+          let atk = 0;
+          let bdm = 0;
+          if (v['atkportee'] && v['atkportee'] !== '') {
+            atk = values.pnj_dex || 0;
+            if (psyint) atk = values.pnj_int || 0;
+            if (psyinf) atk = values.pnj_cha || 0;
+            atkRow[`repeating_armes_${newRowID}_armeatk`] = '@{ATKTIR}';
+            if (psyint) atkRow[`repeating_armes_${newRowID}_armeatk`] = '@{ATKPSYINTUI}';
+            if (psyinf) atkRow[`repeating_armes_${newRowID}_armeatk`] = '@{ATKPSYINFLU}';
+            atkRow[`repeating_armes_${newRowID}_armedmcar`] = '0';
+          } else {
+            atk = values.pnj_for || 0;
+            if (psyint) atk = values.pnj_int || 0;
+            if (psyinf) atk = values.pnj_cha || 0;
+            bdm = (psyint || psyinf) ? 0 : atk;
+            atkRow[`repeating_armes_${newRowID}_armeatk`] = '@{ATKCAC}';
+            if (psyint) atkRow[`repeating_armes_${newRowID}_armeatk`] = '@{ATKPSYINTUI}';
+            if (psyinf) atkRow[`repeating_armes_${newRowID}_armeatk`] = '@{ATKPSYINFLU}';
+            atkRow[`repeating_armes_${newRowID}_armedmcar`] = (psyint || psyinf) ? '0' : '@{FOR}';
+          }
+          if (tohit !== atk) atkRow[`repeating_armes_${newRowID}_armeatkdiv`] = tohit - atk;
+          atkRow[`repeating_armes_${newRowID}_armejetd`] = v['atkjet'];
+          atkRow[`repeating_armes_${newRowID}_armecrit`] = v['atkcrit'];
+          atkRow[`repeating_armes_${newRowID}_armedmg`] = v['atkdmg'];
+          atkRow[`repeating_armes_${newRowID}_armedmnbde`] = v['atkdmnbde'];
+          atkRow[`repeating_armes_${newRowID}_armedmde`] = v['atkdmde'];
+          let dmdiv = parseInt(v['atkdmbonus']) || 0;
+          if (dmdiv !== bdm) atkRow[`repeating_armes_${newRowID}_armedmdiv`] = dmdiv - bdm;
+          atkRow[`repeating_armes_${newRowID}_armeportee`] = v['atkportee'];
+          atkRow[`repeating_armes_${newRowID}_armespec`] = v['atkspec'];
+          setAttrs(atkRow);
         });
       }
     });
-    // encombrement (refresh)
-    encumbrance();
-    // CARACS
+    setAttrs(attrs);
+  });
+}
+
+on('change:type_personnage', function (eventInfo) {
+  if (eventInfo.previousValue === 'pnj' && eventInfo.newValue === 'pj') convertToPC();
+  // if (eventInfo.previousValue === 'pj' && eventInfo.newValue === 'pnj') convertToNPC();
+  getAttrs(['type_personnage'], function (value) {
+    let attrs = {};
+    attrs['type_fiche'] = value.type_personnage;
+    if (value.type_personnage === 'pnj') attrs['pnj_togm'] = '/w gm ';
+    setAttrs(attrs);
+    consoleLog(attrs);
+  });
+});
+
+on('change:pv', function () {
+  getAttrs(['PV', 'PV_max', 'LAST_PV', 'SEUILBG', 'BLESSURE'], function (values) {
+    var seuilbg = parseInt(values.SEUILBG) || 0;
+    var max_pv = parseInt(values.PV_max) || 0;
+    var last_pv = parseInt(values.LAST_PV) || max_pv;
+    var curr_pv = parseInt(values.PV) || 0;
+    var blessure = values.BLESSURE;
+    if (seuilbg > 0) {
+      if (last_pv - curr_pv >= seuilbg || curr_pv === 0) blessure = '1';
+    }
+    setAttrs({
+      LAST_PV: values.PV,
+      BLESSURE: blessure
+    });
+  });
+});
+
+function attrStation(attr) {
+  return [`POSTE_${attr}_NOM`, `POSTE_${attr}_BONUS`];
+}
+
+function setStation(v, attr, fill) {
+  let attrn = '';
+  let attrb = '';
+  if (attr === 'CAN') {
+    attrn = 'repeating_armesv_armecan_nom';
+    attrb = 'repeating_armesv_armecan_bonus';
+  } else {
+    attrn = `POSTE_${attr}_NOM`;
+    attrb = `POSTE_${attr}_BONUS`;
+  }
+  let station_name = v[attrn] || '';
+  station_name = station_name != '' ? `@{${station_name}|${fill[0]}}` : '0';
+  let station_bonus = parseInt(v[attrb]) || 0;
+  let station = {};
+  let station_attr = '';
+  if (attr === 'CAN') {
+    station_attr = 'repeating_armesv_armecan';
+  } else {
+    station_attr = `POSTE_${attr}`;
+  }
+  station[station_attr] = `[[${station_name}]][${fill[1]}] + ${station_bonus}[${fill[2]}]`;
+  setAttrs(station);
+}
+
+on([
+  'change:poste_pil_nom',
+  'change:poste_pil_bonus'
+].join(' '), function () {
+  getAttrs(attrStation('PIL'), function (values) {
+    setStation(values, 'PIL', ['DEX', 'DEX pilote', 'Pilotage']);
+  });
+});
+
+on([
+  'change:poste_mot_nom',
+  'change:poste_mot_bonus'
+].join(' '), function () {
+  getAttrs(attrStation('MOT'), function (values) {
+    setStation(values, 'MOT', ['INT', 'INT mécano', 'Moteurs']);
+  });
+});
+
+on([
+  'change:poste_sen_nom',
+  'change:poste_sen_bonus'
+].join(' '), function () {
+  getAttrs(attrStation('SEN'), function (values) {
+    setStation(values, 'SEN', ['INT', 'INT scan', 'Electronique/Investigation']);
+  });
+});
+
+on([
+  'change:poste_ord_nom',
+  'change:poste_ord_bonus'
+].join(' '), function () {
+  getAttrs(attrStation('ORD'), function (values) {
+    setStation(values, 'ORD', ['INT', 'INT info', 'Electronique']);
+  });
+});
+
+on([
+  'change:repeating_armesv:armecan_nom',
+  'change:repeating_armesv:armecan_bonus'
+].join(' '), function () {
+  getAttrs(['repeating_armesv_armecan_nom', 'repeating_armesv_armecan_bonus'], function (values) {
+    setStation(values, 'CAN', ['DEX', 'DEX canonnier', 'Armes lourdes']);
+  });
+});
+
+function attrRanks(voie) {
+  let attrs = [];
+  for (let r = 1; r < 6; r++) {
+    attrs.push(`voie${voie}-${r}`);
+  }
+  return attrs;
+}
+
+function setRank(voie) {
+  getAttrs(attrRanks(voie), function (v) {
+    let vr = 0;
+    for (let r = 1; r < 6; r++) {
+      let attr = v[`voie${voie}-${r}`];
+      if (attr && attr !== '') vr = r;
+    }
+    let rank = {};
+    rank[`RANG_VOIE${voie}`] = vr;
+    setAttrs(rank);
     buildCaracs();
   });
+}
 
-  on('change:character_name', function() {
-    getAttrs(['character_name'], function(values) {
-      var charName = values.character_name;
-      charName = charName.replace(/ "/g, ' «');
-      charName = charName.replace(/" /g, '» ');
-      setAttrs({ character_name: charName })
+on([
+  'change:voie1nom',
+  'change:voie1-1',
+  'change:voie1-2',
+  'change:voie1-3',
+  'change:voie1-4',
+  'change:voie1-5'
+].join(' '), function () {
+  setRank('1');
+});
+
+on([
+  'change:voie2nom',
+  'change:voie2-1',
+  'change:voie2-2',
+  'change:voie2-3',
+  'change:voie2-4',
+  'change:voie2-5'
+].join(' '), function () {
+  setRank('2');
+});
+
+on([
+  'change:voie3nom',
+  'change:voie3-1',
+  'change:voie3-2',
+  'change:voie3-3',
+  'change:voie3-4',
+  'change:voie3-5'
+].join(' '), function () {
+  setRank('3');
+});
+
+on([
+  'change:voie4nom',
+  'change:voie4-1',
+  'change:voie4-2',
+  'change:voie4-3',
+  'change:voie4-4',
+  'change:voie4-5'
+].join(' '), function () {
+  setRank('4');
+});
+
+on([
+  'change:voie5nom',
+  'change:voie5-1',
+  'change:voie5-2',
+  'change:voie5-3',
+  'change:voie5-4',
+  'change:voie5-5'
+].join(' '), function () {
+  setRank('5');
+});
+
+on([
+  'change:voie6nom',
+  'change:voie6-1',
+  'change:voie6-2',
+  'change:voie6-3',
+  'change:voie6-4',
+  'change:voie6-5'
+].join(' '), function () {
+  setRank('6');
+});
+
+on([
+  'change:voie7nom',
+  'change:voie7-1',
+  'change:voie7-2',
+  'change:voie7-3',
+  'change:voie7-4',
+  'change:voie7-5'
+].join(' '), function () {
+  setRank('7');
+});
+
+on([
+  'change:voie8nom',
+  'change:voie8-1',
+  'change:voie8-2',
+  'change:voie8-3',
+  'change:voie8-4',
+  'change:voie8-5'
+].join(' '), function () {
+  setRank('8');
+});
+
+on([
+  'change:voie9nom',
+  'change:voie9-1',
+  'change:voie9-2',
+  'change:voie9-3',
+  'change:voie9-4',
+  'change:voie9-5'
+].join(' '), function () {
+  setRank('9');
+});
+
+function setArmorMalus() {
+  getAttrs(['DEFARMUREON', 'DEFARMUREMALUS'], function (values) {
+    let armure_on = values.DEFARMUREON || 0;
+    let armure_malus = values.DEFARMUREMALUS || 0;
+    setAttrs({
+      ARMURE_MALUS: armure_on * armure_malus
     });
   });
+}
 
-  /**
-   * Buffs de personnage
-   */
+on([
+  'change:defarmureon',
+  'change:defarmuremalus'
+].join(' '), function (eventInfo) {
+  setArmorMalus();
+});
 
-  function buffValue(v, caracs) {
-    v = v.trim();
-    let bm = 1;
-    if (v.startsWith('-')) bm = -1;
-    if (v.indexOf('2[') !== -1) {
-      v = v.replace('2[','[');
-      bm *= 2;
+on([
+  'change:repeating_armes:armedm2_de',
+  'change:repeating_armes:armedm2_desc'
+].join(' '), function (eventInfo) {
+  getAttrs(['repeating_armes_armedm2_de', 'repeating_armes_armedm2_desc'], function (values) {
+    let dm2_de = values.repeating_armes_armedm2_de || '';
+    let dm2_desc = values.repeating_armes_armedm2_desc || '';
+    let dmg2 = '';
+    if (dm2_desc !== '') dm2_desc = `[${dm2_desc}] `;
+    if (dm2_de !== '') dmg2 = `[[${dm2_de}${dm2_desc}]]`;
+    setAttrs({
+      repeating_armes_armedmg2: dmg2
+    });
+  });
+});
+
+on('change:repeating_armes:armeportee', function () {
+  getAttrs(['repeating_armes_armeportee'], function (value) {
+    let um = '';
+    if (value.repeating_armes_armeportee.indexOf(' m') !== -1) {
+      um = ' m';
+    } else if (value.repeating_armes_armeportee.indexOf('m') !== -1) {
+      um = 'm';
     }
-    v = v.replace(/[\+\-\[\]]/g, '');
-    consoleLog(v);
-    if (isNaN(v)) {
-      // c'est une référence d'attribut
-      if (v.toUpperCase().startsWith('VOIE')) {
-        // c'est un rang dans une voie identifiée par son no
-        let rv = parseInt(v.substring(4).trim()) || 0;
-        if (rv > 0) bv = caracs.rangs[rv - 1];
-      } else if (v.toUpperCase().startsWith('RANG')) {
-        // c'est un rang dans une voie identifiée par son nom
-        let vname = v.substring(5).toUpperCase();
-        let vfound = -1;
-        for (let vn = 0; vn < caracs.voies.length; vn++) {
-          if (caracs.voies[vn] === vname) {
-            vfound = vn;
+    let portee = value.repeating_armes_armeportee;
+    if (um !== '') portee = portee.replace(um, '');
+    let portees = parseInt(portee) || 0;
+    if (portees !== 0) {
+      setAttrs({
+        repeating_armes_armeportees: `${portees}m | ${portees * 2}m (DM/2) | ${portees * 3}m (DM/3)`
+      });
+    }
+  });
+});
+
+function actionLimitee(v) {
+  return (parseInt(v[Object.keys(v)[0]]) || 0) === 1 ? '(L)' : '';
+}
+
+on('change:repeating_armes:arme_al', function () {
+  getAttrs(['repeating_armes_arme_al'], function (value) {
+    setAttrs({
+      repeating_armes_armelim: actionLimitee(value)
+    });
+  });
+});
+
+on('change:repeating_jetcapas:jetcapa_al', function () {
+  getAttrs(['repeating_jetcapas_jetcapa_al'], function (value) {
+    setAttrs({
+      repeating_jetcapas_jetcapalim: actionLimitee(value)
+    });
+  });
+});
+
+function encumbrance() {
+  getSectionIDs('repeating_equipement', function (ids) {
+    const encombrement = {
+      total: 0,
+      zeros: 0
+    }
+    for (let id = 0; id < ids.length; id++) {
+      getAttrs([`repeating_equipement_${ids[id]}_equip-qte`, `repeating_equipement_${ids[id]}_equip-enc`], function (values) {
+        let qte = parseInt(values[Object.keys(values)[0]]) || 0;
+        let enc = parseInt(values[Object.keys(values)[1]]) || 0;
+        if (enc === 0) {
+          encombrement.zeros += qte;
+          if (encombrement.zeros >= 3) {
+            encombrement.total += Math.floor(encombrement.zeros / 3);
+            encombrement.zeros %= 3;
+          }
+        } else {
+          encombrement.total += qte * enc;
+        }
+        setAttrs({
+          total_enc: encombrement.total
+        });
+      });
+    }
+  });
+}
+
+on([
+  'change:repeating_equipement:equip-qte',
+  'change:repeating_equipement:equip-enc'
+].join(' '), function () {
+  encumbrance();
+});
+
+on('change:total_enc', function () {
+  getAttrs(['use_encombrement', 'total_enc', 'seuil_enc'], function (values) {
+    let use_encombrement = values.use_encombrement === 1 ? true : false;
+    if (!use_encombrement) return;
+    let seuil_enc = parseInt(values.seuil_enc) || 0;
+    let encombrement = parseInt(values.total_enc) || 0;
+    if (seuil_enc > 0 && encombrement > 0) {
+      let cond = {};
+      if (encombrement > seuil_enc * 3) {
+        cond.CONDITION = 'I'; // Immobilisé 
+      } else if (encombrement > seuil_enc * 2) {
+        cond.CONDITION = 'L'; // Ralenti
+        cond.ETATDE = '12'; // +Affaibli
+      } else if (encombrement > seuil_enc) {
+        cond.CONDITION = '';
+        cond.JDEX = '1d12';
+        cond.JDEXSUP = '2d12kh1';
+        cond.JDEXSUPHERO = '{2d12kh1, 0d12+10}kh1';
+        cond.JDEXRISQUE = '2d12kl1';
+        cond.ETATDE = '20';
+      } else {
+        cond.CONDITION = '';
+        cond.JDEX = '1d@{ETATDE}';
+        cond.JDEXSUP = '2d@{ETATDE}kh1';
+        cond.JDEXSUPHERO = '{2d@{ETATDE}kh1, 0d20+10}kh1';
+        cond.JDEXRISQUE = '1d12';
+        cond.ETATDE = '20';
+      }
+      if (cond !== null) setAttrs(cond);
+    }
+  });
+});
+
+on('clicked:reset_btn', function () {
+  for (let v = 1; v <= 9; v++) {
+    setRank(v.toString());
+  }
+  buildCaracs();
+  encumbrance();
+});
+
+on('change:mods_atk', function () {
+  let infomsg = 'Syntaxe non reconnue, corrigez SVP...';
+  setAttrs({ INFOMSG: infomsg });
+  getAttrs(['mods_atk', 'CARACS'], function (values) {
+    const aliases = {
+      'attaque': 'att',
+      'attaques': 'att',
+      'cac': 'atc',
+      'contact': 'atc',
+      'cad': 'atd',
+      'distance': 'atd',
+      'psyinf': 'inf',
+      'influ': 'inf',
+      'psyint': 'int',
+      'intui': 'int',
+      'tir': 'atd'
+    };
+    const modifiers = {
+      atc: '',
+      atd: '',
+      inf: '',
+      int: ''
+    };
+    let result = ' ';
+    if (values.mods_atk !== '') {
+      let caracs = JSON.parse(values.CARACS);
+      let mods = values.mods_atk.replace('\n', ';').split(';');
+      for (let mod of mods) {
+        if (mod.trim() === '' || mod.trim().startsWith('-')) continue;
+        let modv = mod.trim().split(' ');
+        let mod_attr = modv.shift().toLowerCase();
+        let mod_sgn = '+';
+        let mod_val = modv.shift();
+        if (mod_val.startsWith('+') || mod_val.startsWith('-')) {
+          mod_sgn = mod_val.substring(0, 1);
+          mod_val = mod_val.substring(1);
+        }
+        if (mod_val.search(/\d+[dD]\d+/) !== -1) {
+          mod_val = `[[${mod_val}]]`;
+        } else {
+          mod_val = buffValue(mod_val, caracs);
+          if (mod_val === 0) continue;
+        }
+        let mod_desc = ` ${mod_sgn}${mod_val}[${modv.join(' ').trim()}]`;
+        switch (mod_attr) {
+          case 'atc':
+          case 'atd':
+          case 'inf':
+          case 'inf':
+            modifiers[mod_attr] += mod_desc;
             break;
-          }
-        }
-        if (vfound > -1) bv = caracs.rangs[vfound];
-      } else {
-        // c'est un mod. de carac
-        bv = caracs[v];
-      }
-    } else { // c'est une valeur fixe
-      bv = v;
-    }
-    return parseInt(bv) * bm || 0;
-  }
-   
-  function parseBuff(buffAttr) {
-    getAttrs([`${buffAttr}_BUFF_LIST`, 'CARACS'], function(v) {
-      let buffAttr = Object.keys(v)[0];
-      let buffList = v[buffAttr];
-      let caracs = JSON.parse(v.CARACS);
-      let buffSum = 0;
-      if (buffList && buffList !== '') {
-        let buffs = buffList.split(';');
-        for (let b = 0; b < buffs.length; b++) {
-          let buff = buffs[b];
-          if (buff && buff !== '') {
-            let delim = (buff.indexOf(':') !== -1) ? ':' : ' ';
-            let buffv = buff.split(delim);
-            let buffName = '';
-            let buffVal = 0;
-            if (delim === ' ') {
-              buffVal = buffValue(buffv[buffv.length - 1], caracs);
-              buffv.pop();
-              buffName = buffv.join(' ').trim();
-            } else {
-              buffName = buffv[0].trim();
-              buffVal = buffValue(buffv[1], caracs);
+          case 'att':
+            for (let attr of ['atc', 'atd', 'inf', 'int']) {
+              modifiers[attr] += mod_desc;
             }
-            consoleLog(buffName);
-            if (!buffName.startsWith('-')) buffSum += buffVal;
-          }
-        }
-      }
-      let attr = {};
-      attr[buffAttr.replace('_LIST', '')] = buffSum;
-      setAttrs(attr);
-    });
-  }
-  
-  function updateBuffs(e) {
-    const caracs = ['FOR', 'DEX', 'CON', 'INT', 'PER', 'CHA'];
-    let mod = e.sourceAttribute.substring(0, 3).toUpperCase();
-    if (!caracs.includes(mod)) return;
-    const attrs = [...caracs, 'ATKCAC', 'ATKTIR', 'PSYINTUI', 'PSYINFLU', 'INIT', 'DEF', 'DEP'];
-    for (let a = 0; a < attrs.length; a++) {
-      attrs[a] = `${attrs[a]}_BUFF_LIST`;
-    }
-    attrs.unshift(mod);
-    getAttrs(attrs, function (values) {
-      let props = Object.keys(values);
-      for (let p = 1; p < props.length; p++) {
-        if (props[p].startsWith(props[0])) continue;
-        if (values[props[p]].indexOf(`[${props[0]}]`) !== -1) parseBuff(props[p].replace('_BUFF_LIST', ''));
-      }
-    });
-  }
-
-  function changeCaracs() {
-    let changeCaracs = '';
-    const caracs = [
-      'FORCE', 'DEXTERITE', 'CONSTITUTION', 'INTELLIGENCE', 'PERCEPTION', 'CHARISME', 'NIVEAU',
-      'RANG_VOIE1', 'RANG_VOIE2', 'RANG_VOIE3', 'RANG_VOIE4', 'RANG_VOIE5', 'RANG_VOIE6', 'RANG_VOIE7', 'RANG_VOIE8', 'RANG_VOIE9',
-      'voie1nom', 'voie2nom', 'voie3nom', 'voie4nom', 'voie5nom', 'voie6nom', 'voie7nom', 'voie8nom', 'voie9nom'
-      ];
-    for (let c = 0; c < caracs.length; c++) {
-      changeCaracs += `change:${caracs[c]} `;
-    }
-    return changeCaracs;
-  }
-
-  on(changeCaracs(), function (eventInfo) {
-    // on reconstruit d'abord l'attribut caché CARACS...
-    buildCaracs();
-    // ... puis on met à jour les buffs qui contiennent une référence à la caractéristique modifiée
-    updateBuffs(eventInfo);
-  });
-
-  on('change:for_buff_list', function() {
-    parseBuff('FOR');
-  });
-
-  on('change:dex_buff_list', function() {
-    parseBuff('DEX');
-  });
-
-  on('change:con_buff_list', function() {
-    parseBuff('CON');
-  });
-
-  on('change:int_buff_list', function() {
-    parseBuff('INT');
-  });
-
-  on('change:per_buff_list', function() {
-    parseBuff('PER');
-  });
-
-  on('change:cha_buff_list', function() {
-    parseBuff('CHA');
-  });
-
-  on('change:atkcac_buff_list', function() {
-    parseBuff('ATKCAC');
-  });
-
-  on('change:atktir_buff_list', function() {
-    parseBuff('ATKTIR');
-  });
-
-  on('change:psyinflu_buff_list', function() {
-    parseBuff('PSYINFLU');
-  });
-
-  on('change:psyintui_buff_list', function() {
-    parseBuff('PSYINTUI');
-  });
-
-  on('change:init_buff_list', function() {
-    parseBuff('INIT');
-  });
-
-  on('change:def_buff_list', function() {
-    parseBuff('DEF');
-  });
-
-  on('change:dep_buff_list', function() {
-    parseBuff('DEP');
-  });
-
-  /**
-   * Buffs de vaisseau
-   */
-  
-  function changeBuff(attr) {
-    return `change:${attr}_buff1 change:${attr}_buff2 change:${attr}_buff3 change:${attr}_buff4 change:${attr}_buff5`;
-  }
-  
-  function attrBuff(attr) {
-    let attrs = [];
-    for (let b=1; b < 6; b++) {
-      attrs.push(`${attr}_BUFF${b}`);
-    }
-    return attrs;
-  }
-  
-  function setBuff(v, buffAttr) {
-    let buffVal = 0;
-    for (let attr = 1; attr < 6; attr++) {
-      buffVal += parseInt(v[`${buffAttr}_BUFF${attr}`]) || 0;
-    }
-    let buff = {};
-    buff[`${buffAttr}_BUFF`] = buffVal;
-    setAttrs(buff);
-  }
-
-  on(changeBuff('for'), function() {
-    getAttrs(attrBuff('FOR'), function(values) {
-      setBuff(values, 'FOR');
-    });
-  });
-  
-  on(changeBuff('dex'), function() {
-    getAttrs(attrBuff('DEX'), function(values) {
-      setBuff(values, 'DEX');
-    });
-  });
-  
-  on(changeBuff('con'), function() {
-    getAttrs(attrBuff('CON'), function(values) {
-      setBuff(values, 'CON');
-    });
-  });
-  
-  on(changeBuff('int'), function() {
-    getAttrs(attrBuff('INT'), function(values) {
-      setBuff(values, 'INT');
-    });
-  });
-  
-  on(changeBuff('per'), function() {
-    getAttrs(attrBuff('PER'), function(values) {
-      setBuff(values, 'PER');
-    });
-  });
-  
-  on(changeBuff('cha'), function() {
-    getAttrs(attrBuff('CHA'), function(values) {
-      setBuff(values, 'CHA');
-    });
-  });
-  
-  on(changeBuff('atktirv'), function() {
-    getAttrs(attrBuff('ATKTIRV'), function(values) {
-      setBuff(values, 'ATKTIRV');
-    });
-  });
-
-  on(changeBuff('defvpil'), function() {
-    getAttrs(attrBuff('DEFVPIL'), function(values) {
-      setBuff(values, 'DEFVPIL');
-    });
-  });
-
-  on(changeBuff('defvsen'), function() {
-    getAttrs(attrBuff('DEFVSEN'), function(values) {
-      setBuff(values, 'DEFVSEN');
-    });
-  });
-
-  on(changeBuff('pev'), function() {
-    getAttrs(attrBuff('PEV'), function(values) {
-      setBuff(values, 'PEV');
-    });
-  });
-
-  on('change:blessure', function() {
-    getAttrs(['BLESSURE'], function(values) {
-      var etatde = (values.BLESSURE == '1') ? '12' : '20';
-      setAttrs({
-        ETATDE: etatde
-      });
-    });
-  });
-
-  on('change:poisse', function() {
-    getAttrs(['POISSE'], function(values) {
-      var jetn = (values.POISSE == '1') ? '2d@{ETATDE}kl1' : '1d@{ETATDE}';
-      var jets = (values.POISSE == '1') ? '1d@{ETATDE}' : '2d@{ETATDE}kh1';
-      var jetsh = (values.POISSE == '1') ? '2d@{ETATDE}kh1' : '{2d@{ETATDE}kh1, 0d20+10}kh1';
-      var jetr = (values.POISSE == '1') ? '2d12kl1' : '1d12';
-      setAttrs({
-        JETNORMAL: jetn,
-        JETSUP: jets,
-        JETSUPHERO: jetsh,
-        JETRISQUE: jetr,
-        JDEX: jetn,
-        JDEXSUP: jets,
-        JDEXSUPHERO: jetsh,
-        JDEXRISQUE: jetr
-      });
-    });
-  });
-
-  on('change:statblock', function(eventInfo) {
-    if (eventInfo.newValue === '') return;
-    getAttrs(['UNIVERS', 'statblock'], function(values) {
-      var messages = '';
-      var pnjObj = importStatblock(values.statblock);
-      if (pnjObj) {
-        consoleLog(pnjObj, 'NPC object');
-        messages = processBaseAttributes(values.UNIVERS, pnjObj);
-        if (pnjObj.hasOwnProperty('Atks')) {
-          var result = processAttacks(values.UNIVERS, pnjObj);
-          if (result !== '' && messages !== '') result = '\n' + result;
-          messages += result;
-          delete pnjObj.Atks;
-        }
-        if (pnjObj.hasOwnProperty('Capas')) {
-          result = processTraits(values.UNIVERS, pnjObj);
-          if (result != '' && messages != '') result = '\n' + result;
-          messages += result;
-          delete pnjObj['Capas'];
-        }
-        // Other attributes go to DIVERS field
-        var divers = '';
-        var otherAttrs = Object.keys(pnjObj);
-        consoleLog(otherAttrs, 'additional data');
-        if (otherAttrs.length > 0) {
-          for (var other = 0; other < otherAttrs.length; other++) {
-            var k = otherAttrs[other];
-            divers += k + ' ' + pnjObj[k] + '\n';
-          }
-        }
-        setAttrs({
-          pnj_divers: divers,
-          sbresult: messages
-        });
-      }
-    });
-  });
- 
-  const npcAtkAttribs = [
-    'atkatt', 
-    'atknom', 
-    'atkjet', 
-    'atkbonus', 
-    'atkcrit', 
-    'atkdmg', 
-    'atkdmnbde', 
-    'atkdmde', 
-    'atkdmbonus', 
-    'atkportee', 
-    'atkspec'
-  ]
-  
-  function convertToPC() {
-    getAttrs([
-      'pnj_for', 'pnj_dex', 'pnj_con', 'pnj_int', 'pnj_per', 'pnj_cha', 
-      'pnj_jetfor', 'pnj_jetdex', 'pnj_jetcon', 'pnj_jetint', 'pnj_jetper', 'pnj_jetcha', 
-      'pnj_init', 'pnj_def', 'pnj_dep', 'pnj_pv', 'pnj_pv_max'
-      ], function(values) {
-      let attrs = {};
-      for (let attr of ['FORCE', 'DEXTERITE', 'CONSTITUTION', 'INTELLIGENCE', 'PERCEPTION', 'CHARISME']) {
-        let attrv = parseInt(values[`pnj_${attr.substring(0,3).toLowerCase()}`]) || 0;
-        attrs[attr] = 10 + (2 * attrv);
-        if (attr === 'DEXTERITE') {
-          let init = parseInt(values.pnj_init) || 0;
-          if (init === attrv + 1) {
-            attrs[attr]++;
-          } else {
-            attrs['INIT_BUFF_LIST'] = 'Bonus Init.';
-            attrs['INIT_BUFF'] = init - attrs[attr];
-          }
-          let defb = 10 + attrv;
-          let def = parseInt(values.pnj_def) || 0;
-          if (def !== defb) {
-            attrs['DEF_BUFF_LIST'] = 'Bonus DEF';
-            attrs['DEF_BUFF'] = def - defb;
-          }
-          attrs['DEX_SUP'] = (values['pnj_jetdex'] === '2d20kh1') ? '@{JDEXSUP}' : '@{JDEX}';
-        } else if (attr === 'CHARISME') {
-          let depb = 10 + attrv;
-          let dep = parseInt(values.pnj_dep) || 0;
-          if (dep !== depb) {
-            attrs['DEP_BUFF_LIST'] = 'Bonus DEP';
-            attrs['DEP_BUFF'] = dep - depb;
-          }
-        } else {
-          attrs[`${attr.substring(0,3)}_SUP`] = (values[`pnj_jet${attr.substring(0,3).toLowerCase()}`] === '2d20kh1') ? '@{JETSUP}' : '@{JETNORMAL}';
-        }
-      }
-      attrs['PV'] = parseInt(values.pnj_pv) || 0;
-      attrs['PV_max'] = parseInt(values.pnj_pv_max) || 0;
-      getSectionIDs('repeating_armes', function(ids) {
-        for (let id of ids) {
-          removeRepeatingRow(`repeating_armes_${id}`);
-        }
-      });
-      getSectionIDs('repeating_pnjatk', function(ids) {
-        for (let id of ids) {
-          getAttrs([...npcAtkAttribs.map(attr => `repeating_pnjatk_${id}_${attr}`), 'pnj_for', 'pnj_dex', 'pnj_cha'], function(values) {
-            consoleLog(values);
-            let v = {};
-            for (let attr of npcAtkAttribs) {
-              v[attr] = values[`repeating_pnjatk_${id}_${attr}`] || '';
-            }
-            newRowID = generateRowID();
-            let atkRow = {};
-            atkRow[`repeating_armes_${newRowID}_armeatt`] = v['atkatt'];
-            atkRow[`repeating_armes_${newRowID}_armenom`] = v['atknom'];
-            let psyint = v['atknom'].toLowerCase().includes('psy intuition');
-            let psyinf = v['atknom'].toLowerCase().includes('psy influence');
-            let tohit = parseInt(v['atkbonus']) || 0;
-            let atk = 0;
-            let bdm = 0;
-            if (v['atkportee'] && v['atkportee'] !== '') {
-              atk = values.pnj_dex || 0;
-              if (psyint) atk = values.pnj_int || 0;
-              if (psyinf) atk = values.pnj_cha || 0;
-              atkRow[`repeating_armes_${newRowID}_armeatk`] = '@{ATKTIR}';
-              if (psyint) atkRow[`repeating_armes_${newRowID}_armeatk`] = '@{ATKPSYINTUI}';
-              if (psyinf) atkRow[`repeating_armes_${newRowID}_armeatk`] = '@{ATKPSYINFLU}';
-              atkRow[`repeating_armes_${newRowID}_armedmcar`] = '0';
-            } else {
-              atk = values.pnj_for || 0;
-              if (psyint) atk = values.pnj_int || 0;
-              if (psyinf) atk = values.pnj_cha || 0;
-              bdm = (psyint || psyinf) ? 0 : atk;
-              atkRow[`repeating_armes_${newRowID}_armeatk`] = '@{ATKCAC}';
-              if (psyint) atkRow[`repeating_armes_${newRowID}_armeatk`] = '@{ATKPSYINTUI}';
-              if (psyinf) atkRow[`repeating_armes_${newRowID}_armeatk`] = '@{ATKPSYINFLU}';
-              atkRow[`repeating_armes_${newRowID}_armedmcar`] = (psyint || psyinf) ? '0' : '@{FOR}';
-            }
-            if (tohit !== atk) atkRow[`repeating_armes_${newRowID}_armeatkdiv`] = tohit - atk;
-            atkRow[`repeating_armes_${newRowID}_armejetd`] = v['atkjet'];
-            atkRow[`repeating_armes_${newRowID}_armecrit`] = v['atkcrit'];
-            atkRow[`repeating_armes_${newRowID}_armedmg`] = v['atkdmg'];
-            atkRow[`repeating_armes_${newRowID}_armedmnbde`] = v['atkdmnbde'];
-            atkRow[`repeating_armes_${newRowID}_armedmde`] = v['atkdmde'];
-            let dmdiv = parseInt(v['atkdmbonus']) || 0;
-            if (dmdiv !== bdm) atkRow[`repeating_armes_${newRowID}_armedmdiv`] = dmdiv - bdm;
-            atkRow[`repeating_armes_${newRowID}_armeportee`] = v['atkportee'];
-            atkRow[`repeating_armes_${newRowID}_armespec`] = v['atkspec'];
-            setAttrs(atkRow);
-          });
-        }
-      });
-      setAttrs(attrs);
-    });
-  }
-  
-  on('change:type_personnage', function(eventInfo) {
-    if (eventInfo.previousValue === 'pnj' && eventInfo.newValue === 'pj') convertToPC();
-    // if (eventInfo.previousValue === 'pj' && eventInfo.newValue === 'pnj') convertToNPC();
-    getAttrs(['type_personnage'], function(value) {
-      let attrs = {};
-      attrs['type_fiche'] = value.type_personnage;
-      if (value.type_personnage === 'pnj') attrs['pnj_togm'] = '/w gm ';
-      setAttrs(attrs);
-      consoleLog(attrs);
-    });
-  });
-  
-  on('change:pv', function() {
-    getAttrs(['PV', 'PV_max', 'LAST_PV', 'SEUILBG', 'BLESSURE'], function(values) {
-      var seuilbg = parseInt(values.SEUILBG) || 0;
-      var max_pv = parseInt(values.PV_max) || 0;
-      var last_pv = parseInt(values.LAST_PV) || max_pv;
-      var curr_pv = parseInt(values.PV) || 0;
-      var blessure = values.BLESSURE;
-      if (seuilbg > 0) {
-        if (last_pv - curr_pv >= seuilbg || curr_pv === 0) blessure = '1';
-      }
-      setAttrs({
-        LAST_PV: values.PV,
-        BLESSURE: blessure
-      });
-    });
-  });
-
-  function changeStation(attr) {
-    return `change:poste_${attr}_nom change:poste_${attr}_bonus`;
-  }
-
-  function attrStation(attr) {
-    return [`POSTE_${attr}_NOM`, `POSTE_${attr}_BONUS`];
-  }
-  
-  function setStation(v, attr, fill) {
-    let attrn = '';
-    let attrb = '';
-    if (attr === 'CAN') {
-      attrn = 'repeating_armesv_armecan_nom';
-      attrb = 'repeating_armesv_armecan_bonus';
-    } else {
-      attrn = `POSTE_${attr}_NOM`;
-      attrb = `POSTE_${attr}_BONUS`;
-    }
-    let station_name = v[attrn] || '';
-    station_name = station_name != '' ? `@{${station_name}|${fill[0]}}` : '0';
-    let station_bonus = parseInt(v[attrb]) || 0;
-    let station = {};
-    let station_attr = '';
-    if (attr === 'CAN') {
-      station_attr = 'repeating_armesv_armecan';
-    } else {
-      station_attr = `POSTE_${attr}`;
-    }
-    station[station_attr] = `[[${station_name}]][${fill[1]}] + ${station_bonus}[${fill[2]}]`;
-    setAttrs(station);
-  }
-  
-  on(changeStation('pil'), function() {
-    getAttrs(attrStation('PIL'), function(values) {
-      setStation(values, 'PIL', ['DEX', 'DEX pilote', 'Pilotage']);
-    });
-  });
-
-  on(changeStation('mot'), function() {
-    getAttrs(attrStation('MOT'), function(values) {
-      setStation(values, 'MOT', ['INT', 'INT mécano', 'Moteurs']);
-    }); 
-  });
-
-  on(changeStation('sen'), function() {
-    getAttrs(attrStation('SEN'), function(values) {
-      setStation(values, 'SEN', ['INT', 'INT scan', 'Electronique/Investigation']);
-    });
-  });
-
-  on(changeStation('ord'), function() {
-    getAttrs(attrStation('ORD'), function(values) {
-      setStation(values, 'ORD', ['INT', 'INT info', 'Electronique']);
-    });
-  });
-  
-  on('change:repeating_armesv:armecan_nom change:repeating_armesv:armecan_bonus', function() {
-    getAttrs(['repeating_armesv_armecan_nom', 'repeating_armesv_armecan_bonus'], function(values) {
-      setStation(values, 'CAN', ['DEX', 'DEX canonnier', 'Armes lourdes']);
-    });
-  });
-
-  function changeRanks(voie) {
-    return `change:voie${voie}nom change:voie${voie}-1 change:voie${voie}-2 change:voie${voie}-3 change:voie${voie}-4 change:voie${voie}-5`;
-  }
-  
-  function attrRanks(voie) {
-    let attrs = [];
-    for (let r=1; r < 6; r++) {
-      attrs.push(`voie${voie}-${r}`);
-    }
-    return attrs;
-  }
-  
-  function setRank(voie) {
-    getAttrs(attrRanks(voie), function(v) {
-      let vr = 0;
-      for (let r = 1; r < 6; r++) {
-        let attr = v[`voie${voie}-${r}`];
-        if (attr && attr !== '') vr = r;
-      }
-      let rank = {};
-      rank[`RANG_VOIE${voie}`] = vr;
-      setAttrs(rank);
-      buildCaracs();
-    });
-  }
-
-  on(changeRanks('1'), function() {
-    setRank('1');
-  });
-
-  on(changeRanks('2'), function() {
-    setRank('2');
-  });
-
-  on(changeRanks('3'), function() {
-    setRank('3');
-  });
-
-  on(changeRanks('4'), function() {
-    setRank('4');
-  });
-
-  on(changeRanks('5'), function() {
-    setRank('5');
-  });
-
-  on(changeRanks('6'), function() {
-    setRank('6');
-  });
-
-  on(changeRanks('7'), function() {
-    setRank('7');
-  });
-
-  on(changeRanks('8'), function() {
-    setRank('8');
-  });
-
-  on(changeRanks('9'), function() {
-    setRank('9');
-  });
-  
-  function setArmorMalus() {
-    getAttrs(['DEFARMUREON', 'DEFARMUREMALUS'], function(values) {
-      let armure_on = values.DEFARMUREON || 0;
-      let armure_malus = values.DEFARMUREMALUS || 0;
-      setAttrs({ 
-        ARMURE_MALUS: armure_on * armure_malus
-      });
-    }); 
-  }
-  
-  on('change:defarmureon change:defarmuremalus', function(eventInfo) {
-    setArmorMalus();
-  });
-
-  on('change:repeating_armes:armedm2_de change:repeating_armes:armedm2_desc', function(eventInfo) {
-    getAttrs(['repeating_armes_armedm2_de', 'repeating_armes_armedm2_desc'], function(values) {
-      let dm2_de = values.repeating_armes_armedm2_de || '';
-      let dm2_desc = values.repeating_armes_armedm2_desc || '';
-      let dmg2 = '';
-      if (dm2_desc !== '') dm2_desc = `[${dm2_desc}] `;
-      if (dm2_de !== '') dmg2 = `[[${dm2_de}${dm2_desc}]]`;
-      setAttrs({ 
-        repeating_armes_armedmg2: dmg2 
-      });
-    });
-  });
-  
-  on('change:repeating_armes:armeportee', function() {
-    getAttrs(['repeating_armes_armeportee'], function(value) {
-      let um = '';
-      if (value.repeating_armes_armeportee.indexOf(' m') !== -1) {
-        um = ' m';
-      } else if (value.repeating_armes_armeportee.indexOf('m') !== -1) {
-        um = 'm';
-      }
-      let portee = value.repeating_armes_armeportee;
-      if (um !== '') portee = portee.replace(um,'');
-      let portees = parseInt(portee) || 0;
-      if (portees !== 0) {
-        setAttrs({ 
-          repeating_armes_armeportees: `${portees}m | ${portees*2}m (DM/2) | ${portees*3}m (DM/3)` 
-        });
-      }
-    });
-  });
-  
-  function actionLimitee(v) {
-    return (parseInt(v[Object.keys(v)[0]]) || 0) === 1 ? '(L)' : '';
-  }
-  
-  on('change:repeating_armes:arme_al', function() {
-    getAttrs(['repeating_armes_arme_al'], function(value) {
-      setAttrs({ 
-        repeating_armes_armelim: actionLimitee(value) 
-      });
-    });
-  });
-
-  on('change:repeating_jetcapas:jetcapa_al', function() {
-    getAttrs(['repeating_jetcapas_jetcapa_al'], function(value) {
-      setAttrs({ 
-        repeating_jetcapas_jetcapalim: actionLimitee(value) 
-      });
-    });
-  });
-
-  function encumbrance() {
-    getSectionIDs('repeating_equipement', function(ids) {
-      const encombrement = {
-        total: 0,
-        zeros: 0
-      }
-      for (let id = 0; id < ids.length; id++) {
-        getAttrs([`repeating_equipement_${ids[id]}_equip-qte`, `repeating_equipement_${ids[id]}_equip-enc`], function(values) {
-          let qte = parseInt(values[Object.keys(values)[0]]) || 0;
-          let enc = parseInt(values[Object.keys(values)[1]]) || 0;
-          if (enc === 0) {
-            encombrement.zeros += qte;
-            if (encombrement.zeros >= 3) {
-              encombrement.total += Math.floor(encombrement.zeros / 3);
-              encombrement.zeros %= 3;
-            }
-          } else {
-            encombrement.total += qte*enc;
-          }
-          setAttrs({
-            total_enc: encombrement.total
-          });
-        });
-      }
-    });
-  }
-  
-  on('change:repeating_equipement:equip-qte change:repeating_equipement:equip-enc', function() {
-    encumbrance();
-  });
-  
-  on('change:total_enc', function() {
-    getAttrs(['use_encombrement', 'total_enc', 'seuil_enc'], function(values) {
-      let use_encombrement = values.use_encombrement === 1 ? true : false;
-      if (!use_encombrement) return;
-      let seuil_enc = parseInt(values.seuil_enc) || 0;
-      let encombrement = parseInt(values.total_enc) || 0;
-      if (seuil_enc > 0 && encombrement > 0) {
-        let cond = {};
-        if (encombrement > seuil_enc * 3) {
-          cond.CONDITION = 'I'; // Immobilisé 
-        } else if (encombrement > seuil_enc * 2) {
-          cond.CONDITION = 'L'; // Ralenti
-          cond.ETATDE = '12'; // +Affaibli
-        } else if (encombrement > seuil_enc) {
-          cond.CONDITION = '';
-          cond.JDEX = '1d12';
-          cond.JDEXSUP = '2d12kh1';
-          cond.JDEXSUPHERO = '{2d12kh1, 0d12+10}kh1';
-          cond.JDEXRISQUE = '2d12kl1';
-          cond.ETATDE = '20';
-        } else {
-          cond.CONDITION = '';
-          cond.JDEX = '1d@{ETATDE}';
-          cond.JDEXSUP = '2d@{ETATDE}kh1';
-          cond.JDEXSUPHERO = '{2d@{ETATDE}kh1, 0d20+10}kh1';
-          cond.JDEXRISQUE = '1d12';
-          cond.ETATDE = '20';
-        }
-        if (cond !== null) setAttrs(cond);
-      }
-    });
-  });
-  
-  on('clicked:reset', function() {
-    for (let v=1; v <= 9; v++) {
-      setRank(v.toString());
-    }
-    buildCaracs();
-    encumbrance();
-  });
-  	  
-  on('change:mods_atk', function() {
-    let infomsg = 'Syntaxe non reconnue, corrigez SVP...';
-    setAttrs({ INFOMSG: infomsg });
-    getAttrs(['mods_atk', 'CARACS'], function(values) {
-      const aliases = {
-        'attaque': 'att',
-        'attaques': 'att',
-        'cac': 'atc',
-        'contact': 'atc',
-        'cad': 'atd',
-        'distance': 'atd',
-        'psyinf': 'inf',
-        'influ': 'inf',
-        'psyint': 'int',
-        'intui': 'int',
-        'tir': 'atd'
-      };
-      const modifiers = {
-        atc: '',
-        atcdm: '',
-        atd: '',
-        atddm: '',
-        inf: '',
-        infdm: '',
-        int: '',
-        intdm: ''
-      };
-      let result = ' ';
-      if (values.mods_atk !== '') {
-        let caracs = JSON.parse(values.CARACS);
-        let mods = values.mods_atk.replace('\n', ';').split(';');
-        for (let mod of mods) {
-          if (mod.trim() === '') continue;
-          let modv = mod.trim().split(' ');
-          let mod_attr = modv.shift().toLowerCase();
-          let to_dm = false;
-          if (mod_attr === 'dm') {
-            to_dm = true;
-            mod_attr = modv.shift().toLowerCase();
+            break;
+          default:
             if (Object.keys(aliases).includes(mod_attr)) {
-              if (aliases[mod_attr] === 'att') mod_attr = 'dm';
-              if (aliases[mod_attr] === 'atc') mod_attr = 'atcdm';
-              if (aliases[mod_attr] === 'atd') mod_attr = 'atddm';
-              if (aliases[mod_attr] === 'inf') mod_attr = 'infdm';
-              if (aliases[mod_attr] === 'int') mod_attr = 'intdm';
+              modifiers[aliases[mod_attr]] += mod_desc;
+              result = ' ';
             } else {
-              if (mod_attr === 'att') mod_attr = 'dm';
-              if (mod_attr === 'atc') mod_attr = 'atcdm';
-              if (mod_attr === 'atd') mod_attr = 'atddm';
-              if (mod_attr === 'inf') mod_attr = 'infdm';
-              if (mod_attr === 'int') mod_attr = 'intdm';
+              result = infomsg;
             }
-          }
-          let mod_sgn = '+';
-          let mod_val = modv.shift();
-          if (mod_val.startsWith('+') || mod_val.startsWith('-')) {
-            mod_sgn = mod_val.substring(0,1);
-            mod_val = mod_val.substring(1);
-          }
-          if (to_dm && mod_val.search(/\d+[dD]\d+/) !== -1) {
-            mod_val = `[[${mod_val}]]`;
-          } else {
-            mod_val = buffValue(mod_val, caracs);
-            if (mod_val === 0) continue;
-          }
-          let mod_desc = ` ${mod_sgn}${mod_val}[${modv.join(' ').trim()}]`;
-          switch (mod_attr) {
-            case 'atc':
-            case 'atcdm':
-            case 'atd':
-            case 'atddm':
-            case 'inf':
-            case 'infdm':
-            case 'int':
-            case 'intdm':
-              modifiers[mod_attr] += mod_desc;
-              break;
-            case 'att':
-              for (let attr of ['atc', 'atd', 'inf', 'int']) {
-                modifiers[attr] += mod_desc;
-              }
-              break;
-            case 'dm':
-              for (let attr of ['atcdm', 'atddm', 'infdm', 'intdm']) {
-                modifiers[attr] += mod_desc;
-              }
-            default:
-              if (Object.keys(aliases).includes(mod_attr)) {
-                modifiers[aliases[mod_attr]] += mod_desc;
-                result = ' ';
-              } else {
-                result = infomsg;
-              }
-              break;
-          }
+            break;
         }
       }
-      getSectionIDs('repeating_armes', function(ids) {
-        for (const id of ids) {
-          getAttrs([`repeating_armes_${id}_armeatk`, `repeating_armes_${id}_armeportee`], function(values) {
-            let type = values[Object.keys(values)[0]] || '';
-            let portee = values[Object.keys(values)[1]] || '';
-            let attr = {};
-            if (type === '@{ATKCAC}' || (type === '@{ATKTIR}' && portee === '')) {
-              attr[`repeating_armes_${id}_armebuff`] = modifiers.atc.trim();
-              attr[`repeating_armes_${id}_armebuffdm`] = modifiers.atcdm.trim();
-            } else if (type === '@{ATKTIR}') {
-              attr[`repeating_armes_${id}_armebuff`] = modifiers.atd.trim();
-              attr[`repeating_armes_${id}_armebuffdm`] = modifiers.atddm.trim();
-            } else if (type === '@{ATKPSYINFLU}') {
-              attr[`repeating_armes_${id}_armebuff`] = modifiers.inf.trim();
-              attr[`repeating_armes_${id}_armebuffdm`] = modifiers.infdm.trim();
-            } else if (type === '@{ATKPSYINTUI}') {
-              attr[`repeating_armes_${id}_armebuff`] = modifiers.int.trim();
-              attr[`repeating_armes_${id}_armebuffdm`] = modifiers.intdm.trim();
-            }
-            if (attr !== null) setAttrs(attr);
-          });
+    }
+    getSectionIDs('repeating_armes', function (ids) {
+      for (const id of ids) {
+        getAttrs([`repeating_armes_${id}_armeatk`, `repeating_armes_${id}_armeportee`], function (values) {
+          let type = values[Object.keys(values)[0]] || '';
+          let portee = values[Object.keys(values)[1]] || '';
+          let attr = {};
+          if (type === '@{ATKCAC}' || (type === '@{ATKTIR}' && portee === '')) {
+            attr[`repeating_armes_${id}_armebuff`] = modifiers.atc.trim();
+          } else if (type === '@{ATKTIR}') {
+            attr[`repeating_armes_${id}_armebuff`] = modifiers.atd.trim();
+          } else if (type === '@{ATKPSYINFLU}') {
+            attr[`repeating_armes_${id}_armebuff`] = modifiers.inf.trim();
+          } else if (type === '@{ATKPSYINTUI}') {
+            attr[`repeating_armes_${id}_armebuff`] = modifiers.int.trim();
+          }
+          if (attr !== null) setAttrs(attr);
+        });
+      }
+    });
+    consoleLog(`[${result}]`);
+    setAttrs({ INFOMSG: result });
+  });
+});
+
+on('change:mods_atkdm', function () {
+  let infomsg = 'Syntaxe non reconnue, corrigez SVP...';
+  setAttrs({ INFOMSG: infomsg });
+  getAttrs(['mods_atkdm', 'CARACS'], function (values) {
+    const aliases = {
+      'attaque': 'att',
+      'attaques': 'att',
+      'cac': 'atc',
+      'contact': 'atc',
+      'cad': 'atd',
+      'distance': 'atd',
+      'psyinf': 'inf',
+      'influ': 'inf',
+      'psyint': 'int',
+      'intui': 'int',
+      'tir': 'atd'
+    };
+    const modifiers = {
+      atc: '',
+      atd: '',
+      inf: '',
+      int: ''
+    };
+    let result = ' ';
+    if (values.mods_atkdm !== '') {
+      let caracs = JSON.parse(values.CARACS);
+      let mods = values.mods_atkdm.replace('\n', ';').split(';');
+      for (let mod of mods) {
+        if (mod.trim() === '' || mod.trim().startsWith('-')) continue;
+        let modv = mod.trim().split(' ');
+        let mod_attr = modv.shift().toLowerCase();
+        let mod_sgn = '+';
+        let mod_val = modv.shift();
+        if (mod_val.startsWith('+') || mod_val.startsWith('-')) {
+          mod_sgn = mod_val.substring(0, 1);
+          mod_val = mod_val.substring(1);
         }
-      });
-      consoleLog(`[${result}]`);
-      setAttrs({ 
-        INFOMSG: result 
-      });
+        if (mod_val.search(/\d+[dD]\d+/) !== -1) {
+          mod_val = `[[${mod_val}]]`;
+        } else {
+          mod_val = buffValue(mod_val, caracs);
+          if (mod_val === 0) continue;
+        }
+        let mod_desc = ` ${mod_sgn}${mod_val}[${modv.join(' ').trim()}]`;
+        switch (mod_attr) {
+          case 'atc':
+          case 'atd':
+          case 'inf':
+          case 'int':
+            modifiers[mod_attr] += mod_desc;
+            break;
+          case 'att':
+            for (let attr of ['atc', 'atd', 'inf', 'int']) {
+              modifiers[attr] += mod_desc;
+            }
+            break;
+          default:
+            if (Object.keys(aliases).includes(mod_attr)) {
+              modifiers[aliases[mod_attr]] += mod_desc;
+              result = ' ';
+            } else {
+              result = infomsg;
+            }
+            break;
+        }
+      }
+    }
+    getSectionIDs('repeating_armes', function (ids) {
+      for (const id of ids) {
+        getAttrs([`repeating_armes_${id}_armeatk`, `repeating_armes_${id}_armeportee`], function (values) {
+          let type = values[Object.keys(values)[0]] || '';
+          let portee = values[Object.keys(values)[1]] || '';
+          let attr = {};
+          if (type === '@{ATKCAC}' || (type === '@{ATKTIR}' && portee === '')) {
+            attr[`repeating_armes_${id}_armebuffdm`] = modifiers.atc.trim();
+          } else if (type === '@{ATKTIR}') {
+            attr[`repeating_armes_${id}_armebuffdm`] = modifiers.atd.trim();
+          } else if (type === '@{ATKPSYINFLU}') {
+            attr[`repeating_armes_${id}_armebuffdm`] = modifiers.inf.trim();
+          } else if (type === '@{ATKPSYINTUI}') {
+            attr[`repeating_armes_${id}_armebuffdm`] = modifiers.int.trim();
+          }
+          if (attr !== null) setAttrs(attr);
+        });
+      }
+    });
+    consoleLog(`[${result}]`);
+    setAttrs({ INFOMSG: result });
+  });
+});
+
+const conditions = {
+  'aveugle': 'A',
+  'effraye': 'F',
+  'etourdi': 'E',
+  'immobilise': 'I',
+  'panique': 'P',
+  'ralenti': 'L',
+  'renverse': 'R',
+  'surpris': 'S'
+}
+
+const conditions_data = {
+  '': {
+    'atc': 0,
+    'atd': 0,
+    'def': 0,
+    'init': 0,
+    'title': ''
+  },
+  'A': {
+    'atc': 5,
+    'atd': 10,
+    'def': 5,
+    'init': 5,
+    'title': 'Aveuglé'
+  },
+  'E': {
+    'atc': 0,
+    'atd': 0,
+    'def': 5,
+    'init': 0,
+    'title': 'Etourdi'
+  },
+  'F': {
+    'atc': 5,
+    'atd': 5,
+    'def': 0,
+    'init': 0,
+    'title': 'Effrayé'
+  },
+  'I': {
+    'atc': 0,
+    'atd': 0,
+    'def': 0,
+    'init': 0,
+    'title': 'Immobilisé'
+  },
+  'P': {
+    'atc': 0,
+    'atd': 0,
+    'def': 2,
+    'init': 0,
+    'title': 'Paniqué'
+  },
+  'L': {
+    'atc': 0,
+    'atd': 0,
+    'def': 0,
+    'init': 0,
+    'title': 'Ralenti'
+  },
+  'R': {
+    'atc': 5,
+    'atd': 5,
+    'def': 5,
+    'init': 0,
+    'title': 'Renversé'
+  },
+  'S': {
+    'atc': 0,
+    'atd': 0,
+    'def': 5,
+    'init': 0,
+    'title': 'Surpris'
+  }
+}
+
+function applyConditions(buffs, conditionAttr, s) {
+  if (conditionAttr === '') return;
+  for (let cond of conditionAttr) {
+    buffs.atc += s * conditions_data[cond].atc;
+    buffs.atd += s * conditions_data[cond].atd;
+    buffs.def += s * conditions_data[cond].def;
+    buffs.init += s * conditions_data[cond].init;
+  }
+}
+
+on([
+  'clicked:cond_aveugle',
+  'clicked:cond_effraye',
+  'clicked:cond_etourdi',
+  'clicked:cond_immobilise',
+  'clicked:cond_panique',
+  'clicked:cond_ralenti',
+  'clicked:cond_renverse',
+  'clicked:cond_surpris'
+].join(' '), function (eventInfo) {
+  var clickedCondition = conditions[eventInfo.triggerName.replace('clicked:cond_', '')];
+  getAttrs(['PCONDITION', 'CONDITION', 'ATKCAC_BUFF', 'ATKTIR_BUFF', 'INIT_BUFF', 'DEF_BUFF', 'ETATDE'], function (values) {
+    let buffs = {
+      'atc': parseInt(values.ATKCAC_BUFF) || 0,
+      'atd': parseInt(values.ATKTIR_BUFF) || 0,
+      'def': parseInt(values.DEF_BUFF) || 0,
+      'init': parseInt(values.INIT_BUFF) || 0
+    };
+    // debuffs prior condition
+    let pcondition = values.PCONDITION || '';
+    applyConditions(buffs, pcondition, +1);
+    // change condition
+    let condition = values.CONDITION || '';
+    if (condition.includes(clickedCondition)) {
+      condition = condition.replace(clickedCondition, '');
+    } else {
+      condition += clickedCondition;
+    }
+    // buff new condition
+    applyConditions(buffs, condition, -1);
+    // check prior condition for die roll
+    let etatde = values.ETATDE;
+    if (pcondition !== '' && (pcondition.includes(conditions.immobilise) || pcondition.includes(conditions.panique))) etatde = '20';
+    // check condition for die roll
+    if (condition !== '' && (condition.includes(conditions.immobilise) || condition.includes(conditions.panique))) etatde = '12';
+    //
+    let displayConditions = '';
+    if (condition !== '') {
+      for (cond of Object.keys(conditions)) {
+        if (condition.includes(conditions[cond])) {
+          displayConditions += (displayConditions === '' ? '' : ', ') + conditions_data[conditions[cond]].title;
+        }
+      }
+    }
+    if (displayConditions === '') displayConditions = ' ';
+    setAttrs({
+      ATKCAC_BUFF: buffs.atc,
+      ATKTIR_BUFF: buffs.atd,
+      DEF_BUFF: buffs.def,
+      INIT_BUFF: buffs.init,
+      ETATDE: etatde,
+      CONDITION: condition,
+      PCONDITION: condition,
+      conditions: displayConditions
     });
   });
-  
-  const conditions = {
-    'aveugle': 'A',
-    'effraye': 'F',
-    'etourdi': 'E',
-    'immobilise': 'I',
-    'panique': 'P',
-    'ralenti': 'L',
-    'renverse': 'R',
-    'surpris': 'S'
-  }
-  
-  const conditions_data = {
-    '': {
-      'atc': 0,
-      'atd': 0,
-      'def': 0,
-      'init': 0,
-      'title': ''
-    },
-    'A': {
-      'atc': 5,
-      'atd': 10,
-      'def': 5,
-      'init': 5,
-      'title': 'Aveuglé'
-    },
-    'E': {
-      'atc': 0,
-      'atd': 0,
-      'def': 5,
-      'init': 0,
-      'title': 'Etourdi'
-    },
-    'F': {
-      'atc': 5,
-      'atd': 5,
-      'def': 0,
-      'init': 0,
-      'title': 'Effrayé'
-    },
-    'I': {
-      'atc': 0,
-      'atd': 0,
-      'def': 0,
-      'init': 0,
-      'title': 'Immobilisé'
-    },
-    'P': {
-      'atc': 0,
-      'atd': 0,
-      'def': 2,
-      'init': 0,
-      'title': 'Paniqué'
-    },
-    'L': {
-      'atc': 0,
-      'atd': 0,
-      'def': 0,
-      'init': 0,
-      'title': 'Ralenti'
-    },
-    'R': {
-      'atc': 5,
-      'atd': 5,
-      'def': 5,
-      'init': 0,
-      'title': 'Renversé'
-    },
-    'S': {
-      'atc': 0,
-      'atd': 0,
-      'def': 5,
-      'init': 0,
-      'title': 'Surpris'
+});
+
+function hitPoints(attr) {
+  getAttrs(['NIVEAU', 'DV', 'CONSTITUTION', 'PV_NIVEAU', 'PV_BUFF', 'prog_pv'], function (values) {
+    let niveau = parseInt(values.NIVEAU) || 0;
+    if (niveau === 0) return;
+    let dv = parseInt(values.DV) || 0;
+    if (dv === 0) return;
+    let constitution = parseInt(values.CONSTITUTION) || 0;
+    let modcon = 0;
+    if (constitution > 0) modcon = Math.floor((constitution - 10) / 2);
+    let pv_niveau = values.PV_NIVEAU || '';
+    let pv = [];
+    if (attr === 'niveau' || attr === 'constitution' || attr === 'pv_buff') {
+      if (pv_niveau !== '') pv = JSON.parse(pv_niveau);
     }
-  }
-  
-  function applyConditions(buffs, conditionAttr, s) {
-    if (conditionAttr === '') return;
-    for (let cond of conditionAttr) {
-      buffs.atc += s * conditions_data[cond].atc;
-      buffs.atd += s * conditions_data[cond].atd;
-      buffs.def += s * conditions_data[cond].def;
-      buffs.init += s * conditions_data[cond].init;
-    }
-  }
-  
-  function clickedConditions() {
-    let clickedConditions = '';
-    for (let condition of Object.keys(conditions)) {
-      clickedConditions += `clicked:cond_${condition} `;
-    }
-    return clickedConditions;
-  }
-  
-  on(clickedConditions(), function(eventInfo) {
-    var clickedCondition = conditions[eventInfo.triggerName.replace('clicked:cond_','')];
-    getAttrs(['PCONDITION', 'CONDITION', 'ATKCAC_BUFF', 'ATKTIR_BUFF', 'INIT_BUFF', 'DEF_BUFF', 'ETATDE'], function(values) {
-      let buffs = {
-        'atc': parseInt(values.ATKCAC_BUFF) || 0,
-        'atd': parseInt(values.ATKTIR_BUFF) || 0,
-        'def': parseInt(values.DEF_BUFF) || 0,
-        'init': parseInt(values.INIT_BUFF) || 0
-      };
-      // debuffs prior condition
-      let pcondition = values.PCONDITION || '';
-      applyConditions(buffs, pcondition, +1);
-      // change condition
-      let condition = values.CONDITION || '';
-      if (condition.includes(clickedCondition)) {
-        condition = condition.replace(clickedCondition,'');
+    let average = (parseInt(values.prog_pv) || 0 === 1) ? 1 + (dv / 2) : 0;
+    let pv_buff = parseInt(values.PV_BUFF) || 0;
+    let pv_max = 0;
+    for (let n = 1; n <= niveau; n++) {
+      let pvie = 0;
+      if (n === 1) {
+        pvie = dv + modcon; // niveau 1 : Max. DV + Mod. CON
       } else {
-        condition += clickedCondition;
-      }
-      // buff new condition
-      applyConditions(buffs, condition, -1);
-      // check prior condition for die roll
-      let etatde = values.ETATDE;
-      if (pcondition !== '' && (pcondition.includes(conditions.immobilise) || pcondition.includes(conditions.panique))) etatde = '20';
-      // check condition for die roll
-      if (condition !== '' && (condition.includes(conditions.immobilise) || condition.includes(conditions.panique))) etatde = '12';
-      //
-      let displayConditions = '';
-      if (condition !== '') {
-        for (cond of Object.keys(conditions)) {
-          if (condition.includes(conditions[cond])) {
-            displayConditions += (displayConditions === '' ? '' : ', ') + conditions_data[conditions[cond]].title;
+        if (n > 10) { // niveaux > 10 : 1 ou 2 PV selon DV
+          if (dv >= 10) pvie = 2;
+          else pvie = 1;
+        } else { // niveaux <= 10
+          if (n % 2 === 0) { // niveau pair
+            if (n > pv.length) { // nouveau niveau
+              if (average !== 0) {
+                pvie = average; // ... soit moyenne du DV + 1
+              } else {
+                pvie = getRandom(dv); // ... soit tirage de DV
+              }
+              if (modcon < 0) pvie += modcon; // ... + Mod. CON si négative
+              if (pvie < 0) pvie = 0; // ... mais on ne perd pas de PV
+            } else { // niveau existant
+              pvie = pv[n - 1];
+            }
+          } else { // niveau impair
+            if (modcon > 0) pvie = modcon; // Mod. CON si positif
           }
         }
       }
-      if (displayConditions === '') displayConditions = ' ';
-      setAttrs({
-        ATKCAC_BUFF: buffs.atc,
-        ATKTIR_BUFF: buffs.atd,
-        DEF_BUFF: buffs.def,
-        INIT_BUFF: buffs.init,
-        ETATDE: etatde,
-        CONDITION: condition,
-        PCONDITION: condition,
-        conditions: displayConditions
-      });
+      if (n > pv.length) pv.push(pvie);
+      else pv[n - 1] = pvie;
+      pv_max += pvie;
+    }
+    pv_max += pv_buff;
+    setAttrs({
+      PV_NIVEAU: JSON.stringify(pv),
+      PV_max: pv_max,
+      PV: pv_max
     });
   });
+}
+
+on([
+  'change:niveau',
+  'change:dv',
+  'change:constitution',
+  'change:pv_buff',
+  'change:prog_pv'
+].join(' '), function (eventInfo) {
+  hitPoints(eventInfo.sourceAttribute);
+});
+
+on('clicked:dv_btn', function () {
+  getAttrs(['NIVEAU'], function (value) {
+    let niveau = parseInt(value.NIVEAU) || 0;
+    if (niveau > 0 && niveau <= 20) {
+      setAttrs({
+        NIVEAU: niveau + 1
+      });
+    }
+  });
+});
 
 </script>
 <!-- FIN SCRIPTS / SHEET WORKERS -->


### PR DESCRIPTION
@Ulty : 

Remise de la fiche CG à iso-fonctionnalité avec la fiche COC : 
- Ajout buff et calcul auto des PV
- Modif. sheetworker pour éviter erreurs dans la console API
- Homogénéisation des noms des roll buttons
- Séparation des buffs circonstanciels de combat en deux champs : un pour le jet d'attaque et un pour le jet de dommages
- Ajout de cases à cocher pour lancer ou nom le jet d'attaque et le jet de dommages sur les lignes d'armes de la fiche de vaisseau -- idem fiche PJ et PNJ (demande forum BBe)
